### PR TITLE
Projekt-Integration von `Videoschnitt.Engine`

### DIFF
--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -12,9 +12,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kurmann.Videoschnitt.Engine" Version="0.4.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Engine\Engine.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Engine/Commands/ICommand.cs
+++ b/src/Engine/Commands/ICommand.cs
@@ -1,0 +1,8 @@
+using CSharpFunctionalExtensions;
+
+namespace Kurmann.Videoschnitt.Engine.Commands;
+
+public interface ICommand<T>
+{
+    Result<T> Execute();
+}

--- a/src/Engine/Commands/SampleModule.cs
+++ b/src/Engine/Commands/SampleModule.cs
@@ -1,0 +1,20 @@
+﻿using CSharpFunctionalExtensions;
+
+namespace Kurmann.Videoschnitt.Engine.Commands;
+
+public class SampleCommand(string? sampleParameter) : ICommand<SampleCommandResult>
+{
+    private readonly string? sampleParameter = sampleParameter;
+
+    public Result<SampleCommandResult> Execute()
+    {
+        if (string.IsNullOrWhiteSpace(sampleParameter))
+            return Result.Failure<SampleCommandResult>("Sample parameter cannot be empty");
+    
+        var commandResult = new SampleCommandResult(sampleParameter);
+
+        return Result.Success(commandResult);
+    }
+}
+
+public record SampleCommandResult(string Result);

--- a/src/Engine/Engine.csproj
+++ b/src/Engine/Engine.csproj
@@ -1,0 +1,54 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <RootNamespace>Kurmann.Videoschnitt.Engine</RootNamespace>
+    <AssemblyName>Kurmann.Videoschnitt.Engine</AssemblyName>
+    <PackageId>Kurmann.Videoschnitt.Engine</PackageId>
+
+    <!-- Package-Tages zur Katalogisierung auf Nuget.org. Mehrere Tags mit Semikolen ";" trennen. -->
+    <PackageTags>Kurmann.Videoschnitt</PackageTags>
+
+    <!-- Die Kurzbeschreibung des NuGet-Packets. Die längere Beschreibung wird als README.md eingebunden -->
+    <Description>Zentrale Steuereinheit für spezialisierte Servicemodule zur Teilautomatisierung in privaten Videoschnittprojekten</Description>
+
+    <!-- Die README.md-Datei, die im NuGet-Paket eingebettet wird. Entspricht gleichzeitig der GitHub Readme-Datei. -->
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+
+    <!-- Die Lizenzdatei, die im NuGet-Paket eingebettet wird (befindet sich im Wurzelverzeichnis). -->
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+
+    <!-- Das Icon, das im NuGet-Paket eingebettet wird (befindet sich im Wurzelverzeichnis). -->
+    <PackageIcon>PackageIcon.png</PackageIcon>
+
+    <!-- Assemblies und Symbol-Dateien werden im NuGet-Paket eingebettet. -->
+    <IncludeContentInPackage>true</IncludeContentInPackage>
+    <IncludeBuildOutput>true</IncludeBuildOutput>
+    <ContentTargetFolders>content</ContentTargetFolders>
+
+    <!-- Integration von Symbolen und Quelltext -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <Deterministic>true</Deterministic>
+
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CSharpFunctionalExtensions" Version="2.41.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+  </ItemGroup>
+
+  <!-- Spezifisch für NuGet-Packetierung -->
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
+    <None Include="..\..\PackageIcon.png" Pack="true" PackagePath="\" />
+  </ItemGroup>
+  
+</Project>

--- a/src/Engine/EngineSettings.cs
+++ b/src/Engine/EngineSettings.cs
@@ -1,0 +1,7 @@
+namespace Kurmann.Videoschnitt.Engine
+{
+    public class EngineSettings
+    {
+        public List<string>? NewOriginalMediaDirectories { get; set; }
+    }
+}

--- a/src/Engine/Hosted/SampleHostedService.cs
+++ b/src/Engine/Hosted/SampleHostedService.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Kurmann.Videoschnitt.Engine.Hosted;
+
+public class SampleHostedService : IHostedService, IDisposable
+{
+    private readonly ILogger<SampleHostedService> _logger;
+    private readonly EngineSettings _settings;
+    private Timer? _timer;
+
+    public SampleHostedService(ILogger<SampleHostedService> logger, IOptions<EngineSettings> options)
+    {
+        _logger = logger;
+        _settings = options.Value;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Sample Service is starting.");
+
+        if (_settings.NewOriginalMediaDirectories != null)
+        {
+            foreach (var directory in _settings.NewOriginalMediaDirectories)
+            {
+                _logger.LogInformation("Configured directory to watch: {directory}", directory);
+            }
+        }
+
+        _timer = new Timer(DoWork, null, TimeSpan.Zero, TimeSpan.FromSeconds(5));
+
+        return Task.CompletedTask;
+    }
+
+    private void DoWork(object? state)
+    {
+        _logger.LogInformation("Sample Service is working. Current time: {time}", DateTimeOffset.Now);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Sample Service is stopping.");
+
+        _timer?.Change(Timeout.Infinite, 0);
+
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _timer?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/Engine/Queries/IQueryService.cs
+++ b/src/Engine/Queries/IQueryService.cs
@@ -1,0 +1,8 @@
+using CSharpFunctionalExtensions;
+
+namespace Kurmann.Videoschnitt.Engine.Queries;
+
+public interface IQueryService<T>
+{
+    public Result<T> Execute();
+}

--- a/src/Engine/Queries/SampleQuery.cs
+++ b/src/Engine/Queries/SampleQuery.cs
@@ -1,0 +1,20 @@
+using CSharpFunctionalExtensions;
+
+namespace Kurmann.Videoschnitt.Engine.Queries;
+
+public class SampleQuery(string? sampleParameter) : IQueryService<SampleQueryResult>
+{
+    private readonly string? sampleParameter = sampleParameter;
+
+    public Result<SampleQueryResult> Execute()
+    {
+        if (string.IsNullOrWhiteSpace(sampleParameter))
+            return Result.Failure<SampleQueryResult>("Sample parameter cannot be empty");
+
+        var sampleEntity = new SampleQueryResult(sampleParameter);
+
+        return Result.Success(sampleEntity);
+    }
+}
+
+public record SampleQueryResult(string Result);

--- a/src/Engine/ServiceCollection.cs
+++ b/src/Engine/ServiceCollection.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Kurmann.Videoschnitt.Engine.Hosted;
+
+namespace Kurmann.Videoschnitt.Engine;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddEngine(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        // Bindet Root-Konfigurationswerte an EngineSettings
+        services.Configure<EngineSettings>(configuration.GetSection("Engine"));
+        
+        // Dienste hinzufügen
+        services.AddHostedService<SampleHostedService>();
+        
+        return services;
+    }
+}


### PR DESCRIPTION
Die Videoschnitt-Engine ist nun als `csproj`-Referenz integriert statt dem NuGet-Package. Somit ist das zugehörige Repository in dieses Monorep integriert 