### PR TITLE
Update Docker container port to 5000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,10 @@ services:
     volumes:
       - ${LOCAL_MEDIA_LIBRARY_PATH}:/media/library:rw
     ports:
-      - "8080:80"
+      - "8080:5000"
     env_file:
       - .env
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
+      - PORT=5000 # Hier den Port eintragen, auf dem der Server laufen soll (Standard: 5000)
       - LOCAL_MEDIA_LIBRARY_PATH=/media/library

--- a/src/Application/Program.cs
+++ b/src/Application/Program.cs
@@ -9,7 +9,7 @@ public class Program
     {
         var builder = WebApplication.CreateBuilder(args);
 
-        var port = Environment.GetEnvironmentVariable("PORT") ?? "80";
+        var port = Environment.GetEnvironmentVariable("PORT") ?? "5000";
         builder.WebHost.UseUrls($"http://*:{port}");
 
         builder.Services.AddRazorPages();


### PR DESCRIPTION
Auf Unix-basierten Systemen (einschließlich Linux, das auf Synology NAS läuft) erfordert das Lauschen auf Ports unter 1024 in der Regel Root-Rechte.

**Lösung**

Eine übliche Lösung besteht darin, einen höheren Port zu verwenden, z. B. 8080 oder 5000, der keine Root-Berechtigungen erfordert. Wir können den Container so konfigurieren, dass er auf einem höheren Port lauscht, und diesen Port dann über Docker Compose oder das Webportal weiterleiten.