### PR TITLE
Pre-Tag für bessere Performance

### DIFF
--- a/src/Application/Pages/Index.razor
+++ b/src/Application/Pages/Index.razor
@@ -2,15 +2,18 @@
 @using Microsoft.AspNetCore.SignalR.Client
 @inject NavigationManager Navigation
 
-<h1>Willkommen bei <strong>Kurmann Videoschnitt</strong></h1>
+<h1>Willkommen bei Kurmann Videoschnitt</h1>
 
-<a class="subtitle-link" href="/swagger">API-Dokumentation</a>
+<a href="/swagger">API-Dokumentation</a>
 
 <div id="logContainer">
-    @foreach (var log in logs)
-    {
-        <div>@log</div>
-    }
+    <pre>
+        @foreach (var log in logs)
+        {
+            // Ausgabe der Log mit Zeilenumbruch (Environment.NewLine)
+            @log.ToString()@Environment.NewLine;
+        }
+    </pre>
 </div>
 
 @code {

--- a/src/Application/wwwroot/css/site.css
+++ b/src/Application/wwwroot/css/site.css
@@ -7,17 +7,15 @@ body {
 
 h1 {
     text-align: center;
-    margin-bottom: 2rem;
-}
-
-.subtitle-link {
-    display: block;
-    text-align: center;
+    margin-bottom: 1rem;
 }
 
 a {
     color: #333; /* Gleiche Farbe wie der Text */
     text-decoration: none;
+    display: block; /* Damit der Link unter dem Titel erscheint */
+    text-align: center;
+    margin-bottom: 2rem;
 }
 
 a:hover {
@@ -33,6 +31,13 @@ a:hover {
     background-color: #fff;
     border-radius: 5px;
     line-height: 1.2rem;
+    overflow: auto; /* Scrollen ermöglichen, wenn zu viele Logs */
+    max-height: 70vh; /* Maximale Höhe für das Log-Fenster */
+}
+
+#logContainer pre {
+    margin: 0;
+    white-space: pre-wrap; /* Zeilenumbruch innerhalb des <pre> */
 }
 
 #blazor-error-ui {
@@ -55,11 +60,11 @@ a:hover {
 }
 
 .blazor-error-boundary {
-    background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTYiIGhlaWdodD0iNDkiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIG92ZXJmbG93PSJoaWRkZW4iPjxkZWZzPjxjbGlwUGF0aCBpZD0iY2xpcDAiPjxyZWN0IHg9IjIzNSIgeT0iNTEiIHdpZHRoPSI1NiIgaGVpZ2h0PSI0OSIvPjwvY2xpcFBhdGg+PC9kZWZzPjxnIGNsaXAtcGF0aD0idXJsKCNjbGlwMCkiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yMzUgLTUxKSI+PHBhdGggZD0iTTI2My41MDYgNTFDMjY0LjcxNyA1MSAyNjUuODEzIDUxLjQ4MzcgMjY2LjYwNiA1Mi4yNjU4TDI2Ny4wNTIgNTIuNzk4NyAyNjcuNTM5IDUzLjYyODMgMjkwLjE4NSA5Mi4xODMxIDI5MC41NDUgOTIuNzk1IDI5MC42NTYgOTIuOTk2QzI5MC44NzcgOTMuNTEzIDI5MSA5NC4wODE1IDI5MSA5NC42NzgyIDI5MSA5Ny4wNjUxIDI4OS4wMzggOTkgMjg2LjYxNyA5OUwyNDAuMzgzIDk5QzIzNy45OTYzIDk5IDIzNiA5Ny4wNjUxIDIzNiA5NC42NzgyIDIzNiA5NC4zNzk5IDIzNi4wMzEgOTQuMDg4NiAyMzYuMDg5IDkzLjgwNzJMMjM2LjMzOCA5My4wMTYyIDI0Ni44NTggODMuMDEzMyAyNDcuMTI4IDgyLjEzMTQgMjY5LjNzNTMuNjI5NCAyNTkuOTYxIDUyLjc5ODUgMjYwLjQwNyA1Mi4yNjU4QzI2MS4yIDUxLjQ4MzcgMjYyLjI5NiA1MSAyNjMuNTA2IDUxWk0yNjMuNTg2IDY2LjAxODNDMjYwLjczNyA2Ni4wMTgzIDI1OS4zMTMgNjcuMTI0NSAyNTkuMzEzIDY5LjMzNyAyNTkuMzEzIDY5LjYxMDIgMjU5LjMzMiA2OS44NjA4IDI1OS4zNzEgNzAuMDg4N0wyNjEuNzk1IDg0LjAxNjEgMjY1LjM4IDg0LjAxNjEgMjY3LjgyMSA2OS43NDc1QzI2Ny44NiA2OS43MzA5IDI2Ny44NzkgNjkuNTg3NyAyNjcuODc5IDY5LjMxNzkgMjY3Ljg3OSA2Ny4xMTgyIDI2Ni40NDggNjYuMDE4MyAyNjMuNTg2IDY2LjAxODNaTTI2My41NzYgODYuMDU0N0MyNjEuMDQ5IDg2LjA1NDcgMjU5Ljc4NiA4Ny4zMDA1IDI1OS43ODYgODkuNzkyMSAyNTkuNzg2IDkyLjI4MzcgMjYxLjA0OSA5My41Mjk1IDI2My41NzYgOTMuNTI5NSAyNjYuMTE2IDkzLjUyOTUgMjY3LjM4NyA5Mi4yODM3IDI2Ny4zODcgODkuNzkyMSAyNjcuMzg3IDg3LjMwMDUgMjY2LjExNiA4Ni4wNTQ3IDI2My41NzYgODYuMDU0N1oiIGZpbGw9IiNGRkU1MDAiIGZpbGwtcnVsZT0iZXZlbm9kZWQiLz48L2c+PC9zdmc+) no-repeat 1rem/1.8rem, #b32121;
     padding: 1rem 1rem 1rem 3.7rem;
-    color: white;
+    color: #b32121;
+    background-color: #f5f5f5; /* Heller Hintergrund statt Bild */
 }
 
 .blazor-error-boundary::after {
-    content: "An error has occurred."
+    content: "An error has occurred.";
 }


### PR DESCRIPTION
Für das Rendering von zahlreichen Log-Einträgen kann die Verwendung eines <pre>-Tags eine bessere Performance bieten, da der Inhalt dann als Blocktext dargestellt wird und weniger DOM-Elemente benötigt werden. Dies reduziert die Anzahl der Knoten im DOM und kann somit die Rendering-Performance verbessern.
