### PR TITLE
Implementierung der manuellen Steuerung des TimerTriggerService

### DIFF
--- a/src/Application/Pages/Index.razor
+++ b/src/Application/Pages/Index.razor
@@ -1,12 +1,14 @@
 ﻿@page "/"
 @using Microsoft.AspNetCore.SignalR.Client
 @inject NavigationManager Navigation
+@inject TimerTriggerService TimerService
 
 <h1>Willkommen bei Kurmann Videoschnitt</h1>
 
 <nav>
     <a @onclick="ExecuteMetadataProcessing">Metadaten-Verarbeitung</a>
-    <a @onclick="ExecuteTimerService">Timer</a>
+    <a @onclick="StartTimerService">Timer starten</a>
+    <a @onclick="StopTimerService">Timer stoppen</a>
     <a href="/swagger">API-Dokumentation</a>
 </nav>
 
@@ -14,7 +16,6 @@
     <pre>
         @foreach (var log in logs)
         {
-            // Ausgabe der Log mit Zeilenumbruch (Environment.NewLine)
             @log.ToString()@Environment.NewLine;
         }
     </pre>
@@ -22,7 +23,6 @@
 
 @code {
     private List<string> logs = new List<string>();
-
     private HubConnection? hubConnection;
 
     protected override async Task OnInitializedAsync()
@@ -31,13 +31,12 @@
             .WithUrl(Navigation.ToAbsoluteUri("/logHub"))
             .Build();
 
-        // Füge initiale Log-Nachrichten hinzu um mitzuteilen, das hier die Logs erscheinen
         logs.Add("Logs werden hier angezeigt.");
 
-        hubConnection.On<string>("ReceiveLogMessage", (message) =>
+        hubConnection.On<string>("ReceiveLogMessage", async (message) =>
         {
             logs.Add(message);
-            InvokeAsync(StateHasChanged);
+            await InvokeAsync(StateHasChanged);
         });
 
         await hubConnection.StartAsync();
@@ -53,15 +52,21 @@
 
     private void ExecuteMetadataProcessing()
     {
-        // Platzhalter für die API-Aufruf zur Metadaten-Verarbeitung
         logs.Add("Metadaten-Verarbeitung gestartet.");
         StateHasChanged();
     }
 
-    private void ExecuteTimerService()
+    private void StartTimerService()
     {
-        // Platzhalter für die API-Aufruf zum Timer-Service
+        TimerService.StartTimer();
         logs.Add("Timer-Service gestartet.");
+        StateHasChanged();
+    }
+
+    private void StopTimerService()
+    {
+        TimerService.StopTimer();
+        logs.Add("Timer-Service gestoppt.");
         StateHasChanged();
     }
 }

--- a/src/Application/Program.cs
+++ b/src/Application/Program.cs
@@ -25,6 +25,7 @@ public class Program
         });
 
         builder.Services.AddHostedService<TimerTriggerService>();
+        builder.Services.AddSingleton<TimerTriggerService>();
 
         builder.Services.AddSingleton<LogHub>();
 

--- a/src/Application/Program.cs
+++ b/src/Application/Program.cs
@@ -24,8 +24,9 @@ public class Program
             c.SwaggerDoc("v1", new OpenApiInfo { Title = "Kurmann Videoschnitt API", Version = "v1"});
         });
 
-        builder.Services.AddHostedService<TimerTriggerService>();
+        // TimerTriggerService sowohl als HostedService als auch als Singleton registrieren
         builder.Services.AddSingleton<TimerTriggerService>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<TimerTriggerService>());
 
         builder.Services.AddSingleton<LogHub>();
 

--- a/src/Application/Services/TimerTriggerService.cs
+++ b/src/Application/Services/TimerTriggerService.cs
@@ -1,20 +1,52 @@
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Kurmann.Videoschnitt.Application.Services
 {
-    public class TimerTriggerService(ILogger<TimerTriggerService> logger, IHubContext<LogHub> hubContext) : IHostedService, IDisposable
+    public class TimerTriggerService : IHostedService, IDisposable
     {
-        private readonly ILogger<TimerTriggerService> _logger = logger;
-        private readonly IHubContext<LogHub> _hubContext = hubContext;
+        private readonly ILogger<TimerTriggerService> _logger;
+        private readonly IHubContext<LogHub> _hubContext;
         private Timer? _timer;
+        private bool _isRunning;
+
+        public TimerTriggerService(ILogger<TimerTriggerService> logger, IHubContext<LogHub> hubContext)
+        {
+            _logger = logger;
+            _hubContext = hubContext;
+        }
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Timer Trigger Service is starting.");
+            _logger.LogInformation("Timer Trigger Service is initialized.");
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Timer Trigger Service is stopping.");
+            _timer?.Change(Timeout.Infinite, 0);
+            _isRunning = false;
+            return Task.CompletedTask;
+        }
+
+        public void StartTimer()
+        {
+            if (_isRunning) return;
+            _isRunning = true;
 
             _timer = new Timer(async (state) => await DoWork(state), null, TimeSpan.Zero, TimeSpan.FromSeconds(5));
+            _logger.LogInformation("Timer Trigger Service started on demand.");
+        }
 
-            return Task.CompletedTask;
+        public void StopTimer()
+        {
+            if (!_isRunning) return;
+            _isRunning = false;
+
+            _timer?.Change(Timeout.Infinite, 0);
+            _logger.LogInformation("Timer Trigger Service stopped on demand.");
         }
 
         private async Task DoWork(object? state)
@@ -22,15 +54,6 @@ namespace Kurmann.Videoschnitt.Application.Services
             var now = DateTimeOffset.Now;
             _logger.LogInformation("Timer Trigger Service is working. Current time: {time}", now);
             await _hubContext.Clients.All.SendAsync("ReceiveLogMessage", $"Timer Trigger Service is working. Current time: {now}");
-        }
-
-        public Task StopAsync(CancellationToken cancellationToken)
-        {
-            _logger.LogInformation("Timer Trigger Service is stopping.");
-
-            _timer?.Change(Timeout.Infinite, 0);
-
-            return Task.CompletedTask;
         }
 
         public void Dispose()

--- a/src/Application/_Imports.razor
+++ b/src/Application/_Imports.razor
@@ -1,3 +1,4 @@
 ﻿@using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.JSInterop
+@using Kurmann.Videoschnitt.Application.Services


### PR DESCRIPTION
**Änderungen:**
- **Neue Funktionalität zum Starten und Stoppen des TimerTriggerService**:
  - Die Blazor-Anwendung wurde angepasst, um den `TimerTriggerService` manuell über die Benutzeroberfläche starten und stoppen zu können.
  - Der `TimerTriggerService` wurde so modifiziert, dass er über die UI-Steuerelemente (Links) in der Blazor-Komponente gestartet und gestoppt werden kann.
  - Die Methoden `StartTimer` und `StopTimer` wurden dem `TimerTriggerService` hinzugefügt, um die Timer-Logik on-demand zu steuern.

**Gründe für die Änderungen:**
- Diese Anpassungen wurden vorgenommen, um eine Machbarkeitsprüfung durchzuführen, ob Hosted Services manuell gestartet und gestoppt werden können.
- Dies ist nützlich für Szenarien, in denen bestimmte Hintergrunddienste nur bei Bedarf ausgeführt werden sollen, um Ressourcen zu schonen und die Anwendungseffizienz zu verbessern.

**Prinzip von Hosted Services:**
- **Definition und Zweck**:
  - Hosted Services sind Hintergrunddienste, die mit der ASP.NET Core-Anwendung gestartet werden und bis zum Beenden der Anwendung laufen.
  - Sie implementieren die Schnittstelle `IHostedService`, die zwei Methoden definiert: `StartAsync` und `StopAsync`.

- **Verwendungsszenarien**:
  - Typische Anwendungsfälle sind wiederkehrende Aufgaben, zeitgesteuerte Ereignisse, oder kontinuierliche Hintergrundoperationen.
  - Beispiele: Timer-gesteuerte Aufgaben, Polling-Dienste, Event-Listener.

- **Manuelle Steuerung**:
  - Normalerweise werden Hosted Services automatisch beim Starten der Anwendung initialisiert und gestartet.
  - In bestimmten Fällen ist es jedoch wünschenswert, die Dienste manuell zu starten und zu stoppen, um mehr Kontrolle und Flexibilität zu haben.
  - Dies kann über zusätzliche Methoden im Dienst erreicht werden, die von der UI oder anderen Teilen der Anwendung aufgerufen werden können.

**Durchgeführte Änderungen im Detail:**
1. **Registrierung des TimerTriggerService**:
   - Der `TimerTriggerService` wurde sowohl als Singleton als auch als HostedService registriert, um sicherzustellen, dass derselbe Dienst von der gesamten Anwendung verwendet werden kann.

2. **Neue Methoden im TimerTriggerService**:
   - `StartTimer`: Startet den Timer-Service und führt periodische Aufgaben durch.
   - `StopTimer`: Stoppt den Timer-Service und beendet die periodischen Aufgaben.

3. **Anpassung der Blazor-Komponente**:
   - Hinzufügen von Methoden zum Starten und Stoppen des Timer-Services über UI-Steuerelemente.
   - Der Service wird direkt in die Komponente injiziert und die Methoden `StartTimer` und `StopTimer` werden aufgerufen.

**Beispielcode:**

### Program.cs
```csharp
builder.Services.AddSingleton<TimerTriggerService>();
builder.Services.AddHostedService(sp => sp.GetRequiredService<TimerTriggerService>());
```

### TimerTriggerService.cs
```csharp
public void StartTimer() { /* Startlogik */ }
public void StopTimer() { /* Stopplogik */ }
```

### index.razor
```razor
@inject TimerTriggerService TimerService

<a @onclick="StartTimerService">Timer starten</a>
<a @onclick="StopTimerService">Timer stoppen</a>

private void StartTimerService() { TimerService.StartTimer(); }
private void StopTimerService() { TimerService.StopTimer(); }
```

Diese Anpassungen bieten eine flexible und effiziente Möglichkeit, den `TimerTriggerService` bei Bedarf zu steuern und zeigen, wie Hosted Services manuell gestartet und gestoppt werden können, um spezifische Anforderungen zu erfüllen.