### PR TITLE
Metadatenverarbeitung mit Wolverine-Benachrichtigungsdienst

### DIFF
--- a/src/Application/Handlers/MetadataProcessedEventLogHandler.cs
+++ b/src/Application/Handlers/MetadataProcessedEventLogHandler.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.SignalR;
+using Kurmann.Videoschnitt.Features.MetadataProcessor.Events;
+
+namespace Kurmann.Videoschnitt.Application;
+
+public class MetadataProcessedEventLogHandler
+{
+    private readonly IHubContext<LogHub> _logHubContext;
+
+    public MetadataProcessedEventLogHandler(IHubContext<LogHub> logHubContext)
+    {
+        _logHubContext = logHubContext;
+    }
+
+    public async Task Handle(MetadataProcessedEvent message)
+    {
+        var logMessage = $"Metadaten wurden erfolgreich verarbeitet: {message.Message}";
+        await _logHubContext.Clients.All.SendAsync("ReceiveLogMessage", logMessage);
+        Console.WriteLine(logMessage);
+    }
+}

--- a/src/Application/Handlers/ProcessMetadataRequestHandler.cs
+++ b/src/Application/Handlers/ProcessMetadataRequestHandler.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.SignalR;
+using Kurmann.Videoschnitt.Features.MetadataProcessor.Events;
+
+namespace Kurmann.Videoschnitt.Application;
+
+public class ProcessMetadataRequestHandler
+{
+    private readonly LogHub _logHub;
+
+    public ProcessMetadataRequestHandler(LogHub logHub)
+    {
+        _logHub = logHub;
+    }
+
+    public async Task Handle(ProcessMetadataRequest message)
+    {
+        var logMessage = "Anfrage zur Verarbeitung der Metadaten erhalten.";
+        await _logHub.SendMessage(logMessage);
+        Console.WriteLine(logMessage);
+    }
+}

--- a/src/Application/Handlers/ProcessMetadataRequestHandler.cs
+++ b/src/Application/Handlers/ProcessMetadataRequestHandler.cs
@@ -12,7 +12,7 @@ public class ProcessMetadataRequestHandler
         _logHubContext = logHubContext;
     }
 
-    public async Task Handle(ProcessMetadataRequest message)
+    public async Task Handle(ProcessMetadataRequest _)
     {
         var logMessage = "Anfrage zur Verarbeitung der Metadaten erhalten.";
         await _logHubContext.Clients.All.SendAsync("ReceiveLogMessage", logMessage);

--- a/src/Application/Handlers/ProcessMetadataRequestHandler.cs
+++ b/src/Application/Handlers/ProcessMetadataRequestHandler.cs
@@ -1,20 +1,21 @@
 using Kurmann.Videoschnitt.Features.MetadataProcessor.Events;
+using Microsoft.AspNetCore.SignalR;
 
 namespace Kurmann.Videoschnitt.Application;
 
 public class ProcessMetadataRequestHandler
 {
-    private readonly LogHub _logHub;
+    private readonly IHubContext<LogHub> _logHubContext;
 
-    public ProcessMetadataRequestHandler(LogHub logHub)
+    public ProcessMetadataRequestHandler(IHubContext<LogHub> logHubContext)
     {
-        _logHub = logHub;
+        _logHubContext = logHubContext;
     }
 
     public async Task Handle(ProcessMetadataRequest message)
     {
         var logMessage = "Anfrage zur Verarbeitung der Metadaten erhalten.";
-        await _logHub.SendMessage(logMessage);
+        await _logHubContext.Clients.All.SendAsync("ReceiveLogMessage", logMessage);
         Console.WriteLine(logMessage);
     }
 }

--- a/src/Application/Handlers/ProcessMetadataRequestHandler.cs
+++ b/src/Application/Handlers/ProcessMetadataRequestHandler.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.SignalR;
 using Kurmann.Videoschnitt.Features.MetadataProcessor.Events;
 
 namespace Kurmann.Videoschnitt.Application;

--- a/src/Application/MessageLogHubService.cs
+++ b/src/Application/MessageLogHubService.cs
@@ -21,37 +21,13 @@ namespace Kurmann.Videoschnitt.Application
         public Task StartAsync(CancellationToken cancellationToken)
         {
             // Abonniere die gewünschten Nachrichten
-            _messageService.Subscribe<StartTimerRequest>(HandleStartTimerRequest);
-            _messageService.Subscribe<StopTimerRequest>(HandleStopTimerRequest);
-            _messageService.Subscribe<ProcessMetadataRequest>(HandleProcessMetadataRequest);
             return Task.CompletedTask;
         }
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
             // Bei Bedarf Abonnement abmelden
-            _messageService.Unsubscribe<StartTimerRequest>(HandleStartTimerRequest);
-            _messageService.Unsubscribe<StopTimerRequest>(HandleStopTimerRequest);
-            _messageService.Unsubscribe<ProcessMetadataRequest>(HandleProcessMetadataRequest);
             return Task.CompletedTask;
-        }
-
-        private async Task HandleStartTimerRequest(StartTimerRequest request)
-        {
-            // Nachricht an den LogHub senden
-            await _hubContext.Clients.All.SendAsync("ReceiveLogMessage", "Anfrage um Timer zu starten: " + request.Timestamp);
-        }
-
-        private async Task HandleStopTimerRequest(StopTimerRequest request)
-        {
-            // Nachricht an den LogHub senden
-            await _hubContext.Clients.All.SendAsync("ReceiveLogMessage", "Anfrage um Timer zu stoppen: " + request.Timestamp);
-        }
-
-        private async Task HandleProcessMetadataRequest(ProcessMetadataRequest request)
-        {
-            // Nachricht an den LogHub senden
-            await _hubContext.Clients.All.SendAsync("ReceiveLogMessage", "Anfrage für Metadatenverarbeitung: " + request.Timestamp);
         }
     }
 }

--- a/src/Application/Pages/Index.razor
+++ b/src/Application/Pages/Index.razor
@@ -27,7 +27,7 @@
     private List<string> logs = new List<string>();
     private HubConnection? hubConnection;
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         hubConnection = new HubConnectionBuilder()
             .WithUrl(Navigation.ToAbsoluteUri("/logHub"))
@@ -40,6 +40,8 @@
             logs.Add(message);
             await InvokeAsync(StateHasChanged);
         });
+
+        await hubConnection.StartAsync();
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Features/MetadataProcessor/Events/MetadataProcessedEvent.cs
+++ b/src/Features/MetadataProcessor/Events/MetadataProcessedEvent.cs
@@ -11,5 +11,3 @@ public class MetadataProcessedEvent
 
     public List<FileInfo> ProcessedFiles { get; } = new();
 }
-
-public class ProcessMetadataRequest {}

--- a/src/Features/MetadataProcessor/Events/ProcessMetadataRequest.cs
+++ b/src/Features/MetadataProcessor/Events/ProcessMetadataRequest.cs
@@ -1,0 +1,3 @@
+namespace Kurmann.Videoschnitt.Features.MetadataProcessor.Events;
+
+public class ProcessMetadataRequest {}

--- a/src/Features/MetadataProcessor/Events/ProcessMetadataRequest.cs
+++ b/src/Features/MetadataProcessor/Events/ProcessMetadataRequest.cs
@@ -1,3 +1,3 @@
 namespace Kurmann.Videoschnitt.Features.MetadataProcessor.Events;
 
-public class ProcessMetadataRequest {}
+public record ProcessMetadataRequest {}

--- a/src/Features/MetadataProcessor/Handler/MetadataProcessedEventHandler.cs
+++ b/src/Features/MetadataProcessor/Handler/MetadataProcessedEventHandler.cs
@@ -12,6 +12,5 @@ public class MetadataProcessedEventHandler
     public async Task Handle(MetadataProcessedEvent message)
     {
         // Konkrete Schritte zur Verarbeitung der Metadaten
-        await _metadataProcessingService.ProcessMetadataAsync();
     }
 }

--- a/src/Features/MetadataProcessor/Handler/MetadataProcessedEventHandler.cs
+++ b/src/Features/MetadataProcessor/Handler/MetadataProcessedEventHandler.cs
@@ -1,19 +1,17 @@
+using System.Threading.Tasks;
 using Kurmann.Videoschnitt.Features.MetadataProcessor.Events;
-using Wolverine;
 
 namespace Kurmann.Videoschnitt.Features.MetadataProcessor.Handler;
 
 public class MetadataProcessedEventHandler
 {
-    public void Handle(MetadataProcessedEvent message)
-    {
-        Console.WriteLine($"Metadata processed: {message.Message}");
-        // Weitere Logik zur Verarbeitung der Nachricht
-    }
+    private readonly MetadataProcessingService _metadataProcessingService;
 
-    public void Handle(ProcessMetadataRequest request)
+    public MetadataProcessedEventHandler(MetadataProcessingService metadataProcessingService) => _metadataProcessingService = metadataProcessingService;
+
+    public async Task Handle(MetadataProcessedEvent message)
     {
-        Console.WriteLine("Processing metadata...");
-        // Weitere Logik zur Verarbeitung der Nachricht
-    } 
+        // Konkrete Schritte zur Verarbeitung der Metadaten
+        await _metadataProcessingService.ProcessMetadataAsync();
+    }
 }

--- a/src/Features/MetadataProcessor/Handler/ProcessMetadataRequestHandler.cs
+++ b/src/Features/MetadataProcessor/Handler/ProcessMetadataRequestHandler.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+using Kurmann.Videoschnitt.Features.MetadataProcessor.Events;
+
+namespace Kurmann.Videoschnitt.Features.MetadataProcessor.Handler;
+
+public class ProcessMetadataRequestHandler
+{
+    private readonly MetadataProcessingService _metadataProcessingService;
+
+    public ProcessMetadataRequestHandler(MetadataProcessingService metadataProcessingService) => _metadataProcessingService = metadataProcessingService;
+
+    public async Task Handle(ProcessMetadataRequest message)
+    {
+        // Konkrete Schritte zur Verarbeitung der Metadaten
+        await _metadataProcessingService.ProcessMetadataAsync();
+    }
+}

--- a/src/Features/MetadataProcessor/MetadataProcessingService.cs
+++ b/src/Features/MetadataProcessor/MetadataProcessingService.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Kurmann.Videoschnitt.Features.MetadataProcessor.Handler;
+using Kurmann.Videoschnitt.Features.MetadataProcessor.Events;
 using Wolverine;
 
 namespace Kurmann.Videoschnitt.Features.MetadataProcessor;
@@ -44,10 +45,13 @@ public class MetadataProcessingService
         _logger.LogInformation("Verzeichnis für Metadatenverarbeitung: {directory}", _metadataProcessingDirectory.FullName);
 
         // Simuliere Metadatenverarbeitung
-        await Task.Delay(5000);
+        await Task.Delay(3000);
 
         // todo: Veröffentliche Nachricht über abgeschlossene Metadatenverarbeitung
     
         _logger.LogInformation("Metadatenverarbeitung abgeschlossen.");
+
+        await _bus.PublishAsync(new MetadataProcessedEvent($"Metadatanverarbeitung für Verzeichnis {_metadataProcessingDirectory.FullName} abgeschlossen."));
+        
     }
 }


### PR DESCRIPTION
Das Messaging-Framework Wolverine wurde im Ablauf `ProcessMetadataRequest` integriert. Nach einer simulierten Metadatenverarbeitung von 3 Sekunden wird der `MetadataProcessedEvent` ausgelöst und ebenfalls in der Log-Ausgabe angezeigt.

![image](https://github.com/kurmann/videoschnitt/assets/2642655/a956c6cd-f324-402a-98f3-7e1eb1a53463)
