### PR TITLE
`assembly: WolverineModule`-Attribut

### DIFF
--- a/src/Application/Handlers/MetadataProcessedEventLogHandler.cs
+++ b/src/Application/Handlers/MetadataProcessedEventLogHandler.cs
@@ -3,19 +3,12 @@ using Kurmann.Videoschnitt.Messages.Metadata;
 
 namespace Kurmann.Videoschnitt.Application;
 
-public class MetadataProcessedEventLogHandler
+public class MetadataProcessedEventLogHandler(IHubContext<LogHub> logHubContext)
 {
-    private readonly IHubContext<LogHub> _logHubContext;
-
-    public MetadataProcessedEventLogHandler(IHubContext<LogHub> logHubContext)
-    {
-        _logHubContext = logHubContext;
-    }
-
     public async Task Handle(MetadataProcessedEvent message)
     {
         var logMessage = $"Metadaten wurden erfolgreich verarbeitet: {message.Message}";
-        await _logHubContext.Clients.All.SendAsync("ReceiveLogMessage", logMessage);
+        await logHubContext.Clients.All.SendAsync("ReceiveLogMessage", logMessage);
         Console.WriteLine(logMessage);
     }
 }

--- a/src/Application/Handlers/ProcessMetadataRequestHandler.cs
+++ b/src/Application/Handlers/ProcessMetadataRequestHandler.cs
@@ -3,19 +3,12 @@ using Kurmann.Videoschnitt.Messages.Metadata;
 
 namespace Kurmann.Videoschnitt.Application;
 
-public class ProcessMetadataRequestHandler
+public class ProcessMetadataRequestHandler(IHubContext<LogHub> logHubContext)
 {
-    private readonly IHubContext<LogHub> _logHubContext;
-
-    public ProcessMetadataRequestHandler(IHubContext<LogHub> logHubContext)
-    {
-        _logHubContext = logHubContext;
-    }
-
     public async Task Handle(ProcessMetadataRequest _)
     {
         var logMessage = "Anfrage zur Verarbeitung der Metadaten erhalten.";
-        await _logHubContext.Clients.All.SendAsync("ReceiveLogMessage", logMessage);
+        await logHubContext.Clients.All.SendAsync("ReceiveLogMessage", logMessage);
         Console.WriteLine(logMessage);
     }
 }

--- a/src/Application/Program.cs
+++ b/src/Application/Program.cs
@@ -1,7 +1,6 @@
 using Microsoft.OpenApi.Models;
 using Wolverine;
 using System.Globalization;
-using Kurmann.Videoschnitt.Features.MetadataProcessor;
 
 namespace Kurmann.Videoschnitt.Application;
 
@@ -13,11 +12,7 @@ public class Program
         CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
 
         var builder = WebApplication.CreateBuilder(args);
-        builder.Host.UseWolverine(opts =>
-        {
-            // Fügen Sie so viele andere Assemblys hinzu, wie Sie benötigen
-            opts.Discovery.IncludeAssembly(typeof(MetadataProcessingService).Assembly);
-        });
+        builder.Host.UseWolverine();
 
         var port = Environment.GetEnvironmentVariable("PORT") ?? "5024";
         builder.WebHost.UseUrls($"http://*:{port}");

--- a/src/Features/MetadataProcessor/Properties/AssembyInfo.cs
+++ b/src/Features/MetadataProcessor/Properties/AssembyInfo.cs
@@ -1,0 +1,4 @@
+// Datei: Kurmann.Videoschnitt.Features.MetadataProcessor/Properties/AssemblyInfo.cs
+using Wolverine.Attributes;
+
+[assembly: WolverineModule]


### PR DESCRIPTION
Entfernt die Notwendigkeit für die `Discovery.IncludeAssembly`-Methode, indem das `[assembly: WolverineModule]`-Attribut verwendet wird, um die automatische Erkennung der Handler zu ermöglichen. Projektreferenzen bleiben bestehen, um sicherzustellen, dass die Feature-Assemblies korrekt mitkompiliert werden.

### Änderungen

1. **Feature-Bibliotheken (Kurmann.Videoschnitt.Features.MetadataProcessor)**
   - Hinzufügen des `[assembly: WolverineModule]`-Attributs zur `AssemblyInfo.cs`.

2. **Hauptanwendung (Kurmann.Videoschnitt.Application)**
   - Entfernen der `Discovery.IncludeAssembly`-Methode.

### Beispielcode

#### Vorher: Program.cs in der Hauptanwendung mit `Discovery.IncludeAssembly`

```csharp
builder.Host.UseWolverine(opts =>
{
    // Fügen Sie so viele andere Assemblys hinzu, wie Sie benötigen
    opts.Discovery.IncludeAssembly(typeof(MetadataProcessingService).Assembly);
});

```

#### Nachher: Program.cs in der Hauptanwendung ohne `Discovery.IncludeAssembly`

```csharp
var builder = WebApplication.CreateBuilder(args);
```

#### AssemblyInfo.cs im Feature-Assembly

```csharp
// Datei: Kurmann.Videoschnitt.Features.MetadataProcessor/Properties/AssemblyInfo.cs
using Wolverine;

// Andere Assembly-Attribute...

[assembly: WolverineModule]
```

#### Änderungen an der Projektdatei (.csproj)

Füge die notwendigen Projektverweise hinzu, um sicherzustellen, dass die Feature-Assemblies mitkompiliert werden:

```xml
<Project Sdk="Microsoft.NET.Sdk.Web">

  <ItemGroup>
    <ProjectReference Include="..\Features\MetadataProcessor\MetadataProcessor.csproj" />
    <ProjectReference Include="..\Messages\Messages.csproj" />
  </ItemGroup>

</Project>
```