### PR TITLE
Navigation bereinigt

### DIFF
--- a/src/Application/Pages/Index.razor
+++ b/src/Application/Pages/Index.razor
@@ -10,7 +10,6 @@
 
 <nav>
     <a @onclick="async () => await ExecuteMetadataProcessing()">Metadaten-Verarbeitung</a>
-    <a @onclick="StartTimerService">Timer starten</a>
     <a @onclick="StopTimerService">Timer stoppen</a>
     <a href="/swagger">API-Dokumentation</a>
 </nav>

--- a/src/Application/Pages/Index.razor
+++ b/src/Application/Pages/Index.razor
@@ -10,7 +10,6 @@
 
 <nav>
     <a @onclick="async () => await ExecuteMetadataProcessing()">Metadaten-Verarbeitung</a>
-    <a @onclick="StopTimerService">Timer stoppen</a>
     <a href="/swagger">API-Dokumentation</a>
 </nav>
 

--- a/src/Application/Program.cs
+++ b/src/Application/Program.cs
@@ -47,6 +47,7 @@ public class Program
         app.UseRouting();
         app.UseSwagger();
         app.UseSwagger();
+        app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Kurmann Videoschnitt API v1"));
 
         // Minimal API Endpunkte
         app.MapGet("/api/health", () => Results.Ok(new { status = "Healthy" }));


### PR DESCRIPTION
- Timer-Service läuft nun ständig im Hintergrund und kann nicht gestartet oder gestoppt werden.
- Swagger-UI-Interface wieder instand gesetzt.

![image](https://github.com/kurmann/videoschnitt/assets/2642655/7c4c2470-8fb5-46d3-9c54-bed9d2f34b59)
