### PR TITLE
.NET Options-Pattern für Feature-Bibliotheken

### DIFF
--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -21,5 +21,6 @@
     <ProjectReference Include="..\Messages\Messages.csproj" />
     <ProjectReference Include="..\MetadataProcessor\MetadataProcessor.csproj" />
     <ProjectReference Include="..\TimerService\TimerService.csproj" />
+    <ProjectReference Include="..\ApplicationConfiguration\ApplicationConfiguration.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Application/Handlers/MetadataProcessedEventLogHandler.cs
+++ b/src/Application/Handlers/MetadataProcessedEventLogHandler.cs
@@ -7,7 +7,7 @@ public class MetadataProcessedEventLogHandler(IHubContext<LogHub> logHubContext)
 {
     public async Task Handle(MetadataProcessedEvent message)
     {
-        var logMessage = $"Metadaten wurden erfolgreich verarbeitet: {message.Message}";
+        var logMessage = $"Metadaten für das Verzeichnis '{message.InputDirectory}' wurden erfolgreich verarbeitet.";
         await logHubContext.Clients.All.SendAsync("ReceiveLogMessage", logMessage);
         Console.WriteLine(logMessage);
     }

--- a/src/Application/Pages/Index.razor
+++ b/src/Application/Pages/Index.razor
@@ -57,16 +57,4 @@
         await bus.SendAsync(new ProcessMetadataRequest());
         StateHasChanged();
     }
-
-    private async Task StartTimerService()
-    {
-        // todo: send message to server
-        StateHasChanged();
-    }
-
-    private void StopTimerService()
-    {
-        // todo: send message to server
-        StateHasChanged();
-    }
 }

--- a/src/Application/Program.cs
+++ b/src/Application/Program.cs
@@ -2,6 +2,8 @@ using Microsoft.OpenApi.Models;
 using Wolverine;
 using System.Globalization;
 using Kurmann.Videoschnitt.TimerService;
+using Kurmann.Videoschnitt.ApplicationConfiguration;
+using Kurmann.Videoschnitt.MetadataProcessor;
 
 namespace Kurmann.Videoschnitt.Application;
 
@@ -17,6 +19,17 @@ public class Program
 
         var port = Environment.GetEnvironmentVariable("PORT") ?? "5024";
         builder.WebHost.UseUrls($"http://*:{port}");
+
+                    // Add configuration sources
+        builder.Configuration
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+            .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: true)
+            .AddEnvironmentVariables()
+            .AddUserSecrets<Program>();
+
+        // builder.Services.AddApplicationConfiguration(builder.Configuration);
+        builder.Services.AddMetadataProcessor(builder.Configuration);
 
         builder.Services.AddRazorPages();
         builder.Services.AddServerSideBlazor();

--- a/src/Application/appsettings.Development.json
+++ b/src/Application/appsettings.Development.json
@@ -6,5 +6,7 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "MetadataProcessingDirectory": "/Users/patrickkurmann/Movies/Final Cut Exporte"
+  "MetadataProcessing": {
+    "InputDirectory": "/Users/patrickkurmann/Movies/Final Cut Exporte"
+  }
 }

--- a/src/ApplicationConfiguration/ApplicationConfiguration.csproj
+++ b/src/ApplicationConfiguration/ApplicationConfiguration.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Kurmann.Videoschnitt.ApplicationConfiguration</RootNamespace>
+    <AssemblyName>Kurmann.Videoschnitt.ApplicationConfiguration</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-preview.4.24266.19" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0-preview.4.24266.19" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0-preview.4.24266.19" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0-preview.4.24266.19" />
+  </ItemGroup>
+
+</Project>

--- a/src/ApplicationConfiguration/MetadataProcessingSettings.cs
+++ b/src/ApplicationConfiguration/MetadataProcessingSettings.cs
@@ -1,0 +1,6 @@
+namespace Kurmann.Videoschnitt.ApplicationConfiguration;
+
+public class MetadataProcessingSettings
+{
+    public string? InputDirectory { get; set; }
+}

--- a/src/ApplicationSettings/ApplicationSettings.csproj
+++ b/src/ApplicationSettings/ApplicationSettings.csproj
@@ -1,9 +1,0 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
-</Project>

--- a/src/ApplicationSettings/ApplicationSettings.csproj
+++ b/src/ApplicationSettings/ApplicationSettings.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Messages/Metadata/MetadataProcessedEvent.cs
+++ b/src/Messages/Metadata/MetadataProcessedEvent.cs
@@ -1,13 +1,3 @@
 namespace Kurmann.Videoschnitt.Messages.Metadata;
 
-public class MetadataProcessedEvent
-{
-    public MetadataProcessedEvent(string message)
-    {
-        Message = message;
-    }
-
-    public string Message { get; }
-
-    public List<FileInfo> ProcessedFiles { get; } = new();
-}
+public record MetadataProcessedEvent(DirectoryInfo InputDirectory, List<FileInfo>? ProcessedFiles = null);

--- a/src/MetadataProcessor/MetadataProcessingService.cs
+++ b/src/MetadataProcessor/MetadataProcessingService.cs
@@ -53,7 +53,7 @@ public class MetadataProcessingService
     
         _logger.LogInformation("Metadatenverarbeitung abgeschlossen.");
 
-        await _bus.PublishAsync(new MetadataProcessedEvent($"Metadatanverarbeitung für Verzeichnis {_inputDirectory.FullName} abgeschlossen."));
+        await _bus.PublishAsync(new MetadataProcessedEvent(_inputDirectory));
         
     }
 }

--- a/src/MetadataProcessor/MetadataProcessingService.cs
+++ b/src/MetadataProcessor/MetadataProcessingService.cs
@@ -1,47 +1,50 @@
 using Microsoft.Extensions.Logging;
 using Kurmann.Videoschnitt.Messages.Metadata;
 using Wolverine;
+using Microsoft.Extensions.Options;
+using Kurmann.Videoschnitt.ApplicationConfiguration;
 
 namespace Kurmann.Videoschnitt.MetadataProcessor;
 
 public class MetadataProcessingService
 {
     private readonly ILogger<MetadataProcessingService> _logger;
-    private readonly DirectoryInfo? _metadataProcessingDirectory;
+    private readonly DirectoryInfo? _inputDirectory;
     private readonly IMessageBus _bus;
 
-    public MetadataProcessingService(ILogger<MetadataProcessingService> logger, IMessageBus bus)
+    public MetadataProcessingService(ILogger<MetadataProcessingService> logger, IOptions<MetadataProcessingSettings> settings, IMessageBus bus)
     {
         _logger = logger;
         _bus = bus;
 
-        // Lade Umgebungsvariablen
-        var metadataProcessingDirectoryValue = Environment.GetEnvironmentVariable("METADATA_PROCESSING_DIRECTORY");
-        if (string.IsNullOrEmpty(metadataProcessingDirectoryValue))
+        // Prüfe, ob das Verzeichnis für die Metadatenverarbeitung definiert ist
+        if (string.IsNullOrWhiteSpace(settings.Value?.InputDirectory))
         {
-            _logger.LogWarning("Umgebungsvariable METADATA_PROCESSING_DIRECTORY ist nicht gesetzt.");
-            return;
-        }
-        var directory = new DirectoryInfo(metadataProcessingDirectoryValue);
-        if (directory == null || !directory.Exists)
-        {
-            _logger.LogWarning("Ungültiger oder nicht existierender Wert für Umgebungsvariable METADATA_PROCESSING_DIRECTORY: {value}", metadataProcessingDirectoryValue);
+            _logger.LogWarning("Kein Wert für die Umgebungsvariable 'MetadataProcessing__InputDirectory' gesetzt.");
             return;
         }
 
-        _metadataProcessingDirectory = directory;
+        // Prüfe, ob das Verzeichnis für die Metadatenverarbeitung existiert
+        var directory = new DirectoryInfo(settings.Value.InputDirectory);
+        if (directory == null || !directory.Exists)
+        {
+            _logger.LogWarning("Ungültiger oder nicht existierender Wert für Umgebungsvariable METADATA_PROCESSING_DIRECTORY: {value}", settings.Value.InputDirectory);
+            return;
+        }
+
+        _inputDirectory = directory;
     }
 
     public async Task ProcessMetadataAsync()
     {
         _logger.LogInformation("Metadatenverarbeitung gestartet.");
 
-        if (_metadataProcessingDirectory == null || !_metadataProcessingDirectory.Exists)
+        if (_inputDirectory == null || !_inputDirectory.Exists)
         {
             _logger.LogWarning("Verzeichnis existiert nicht.");
             return;
         }
-        _logger.LogInformation("Verzeichnis für Metadatenverarbeitung: {directory}", _metadataProcessingDirectory.FullName);
+        _logger.LogInformation("Verzeichnis für Metadatenverarbeitung: {directory}", _inputDirectory.FullName);
 
         // Simuliere Metadatenverarbeitung
         await Task.Delay(3000);
@@ -50,7 +53,7 @@ public class MetadataProcessingService
     
         _logger.LogInformation("Metadatenverarbeitung abgeschlossen.");
 
-        await _bus.PublishAsync(new MetadataProcessedEvent($"Metadatanverarbeitung für Verzeichnis {_metadataProcessingDirectory.FullName} abgeschlossen."));
+        await _bus.PublishAsync(new MetadataProcessedEvent($"Metadatanverarbeitung für Verzeichnis {_inputDirectory.FullName} abgeschlossen."));
         
     }
 }

--- a/src/MetadataProcessor/MetadataProcessor.csproj
+++ b/src/MetadataProcessor/MetadataProcessor.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Messages\Messages.csproj" />
+    <ProjectReference Include="..\ApplicationConfiguration\ApplicationConfiguration.csproj" />
   </ItemGroup>
   
 </Project>

--- a/src/MetadataProcessor/ServiceCollectionExtensions.cs
+++ b/src/MetadataProcessor/ServiceCollectionExtensions.cs
@@ -1,11 +1,16 @@
+using Kurmann.Videoschnitt.ApplicationConfiguration;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Kurmann.Videoschnitt.MetadataProcessor;
 
 public static class ServiceCollectionExtensions
 {
-    public static IServiceCollection AddMetadataProcessor(this IServiceCollection services)
-    {
+    public static IServiceCollection AddMetadataProcessor(this IServiceCollection services, IConfiguration configuration)
+    {   
+        // Add configuration sources
+        services.Configure<MetadataProcessingSettings>(configuration.GetSection("MetadataProcessing"));
+
         // Register MetadataProcessingService
         services.AddSingleton<MetadataProcessingService>();
 

--- a/src/Videoschnitt.sln
+++ b/src/Videoschnitt.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Messages", "Messages\Messag
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetadataProcessor", "MetadataProcessor\MetadataProcessor.csproj", "{2ECAA0DB-CBE4-4D5B-868C-8A10219C70F9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApplicationSettings", "ApplicationSettings\ApplicationSettings.csproj", "{8DCC1E75-F353-44B8-AC4F-C5EB0C9B5EBB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +32,9 @@ Global
 		{2ECAA0DB-CBE4-4D5B-868C-8A10219C70F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2ECAA0DB-CBE4-4D5B-868C-8A10219C70F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2ECAA0DB-CBE4-4D5B-868C-8A10219C70F9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8DCC1E75-F353-44B8-AC4F-C5EB0C9B5EBB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8DCC1E75-F353-44B8-AC4F-C5EB0C9B5EBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8DCC1E75-F353-44B8-AC4F-C5EB0C9B5EBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8DCC1E75-F353-44B8-AC4F-C5EB0C9B5EBB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
- Das Feature-Assembly `Kurmann.Videoschnitt.MetadataProcessor` hat nun das Microsoft Options-Pattern angewandt.
- Der `MetadataProcessedEvent` beinhaltet nun typsicher (als `DirectoryInfo`) das Eingabeverzeichnis. Dieses wird in der Webkonsole ausgegeben. 
  ![image](https://github.com/kurmann/videoschnitt/assets/2642655/cf9078e6-6922-468e-a60d-39429e61ac61)
