### PR TITLE
Timer-Service deaktiviert

### DIFF
--- a/src/Application/Program.cs
+++ b/src/Application/Program.cs
@@ -43,8 +43,6 @@ public class Program
 
         builder.Services.AddSingleton<LogHub>();
 
-        builder.Services.AddTimerServices();
-
         var app = builder.Build();
 
         if (!app.Environment.IsDevelopment())


### PR DESCRIPTION
Der Service war zu Anschauungszwecken für das Weblog eingesetzt. Die Funktionalität bleibt erhalten und wird später für zeitgesteuerte Funktionen, bspw. Dateisystemüberwachungen, eingesetzt.