### PR TITLE
Überschreiben der Ports seitens .NET entfernt

### DIFF
--- a/src/Application/Program.cs
+++ b/src/Application/Program.cs
@@ -15,10 +15,6 @@ public class Program
         var builder = WebApplication.CreateBuilder(args);
         builder.Host.UseWolverine();
 
-        var port = Environment.GetEnvironmentVariable("PORT") ?? "5024";
-        builder.WebHost.UseUrls($"http://*:{port}");
-
-                    // Add configuration sources
         builder.Configuration
             .SetBasePath(Directory.GetCurrentDirectory())
             .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)


### PR DESCRIPTION
Das manuelle Setzen der Ports seitens .NET ist entfernt worden. 

Entfernt:

```csharp
var port = Environment.GetEnvironmentVariable("PORT") ?? "5024";
        builder.WebHost.UseUrls($"http://*:{port}");
```

Verhindert somit die folgende .NET Warnung:

```
warn: Microsoft.AspNetCore.Hosting.Diagnostics[15]
      Overriding HTTP_PORTS '8080' and HTTPS_PORTS ''. Binding to values defined by URLS instead 'http://*:5024'.
```

