### PR TITLE
Docker-in-Docker und interner Portwechsel

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,10 +5,8 @@
 	"image": "mcr.microsoft.com/dotnet/nightly/sdk:9.0-preview-noble",
 	"features": {
 		"ghcr.io/devcontainers-contrib/features/ffmpeg-apt-get:1": {},
-		"ghcr.io/devcontainers/features/github-cli:1": {
-			"installDirectlyFromGitHubRelease": true,
-			"version": "latest"
-		}
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
 	},
 	"containerEnv": {
 		"MetadataProcessing__InputDirectory": "/workspaces/videoschnitt/testdata"

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,9 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 # Copy the built application
 COPY --from=build-env /app/out .
 
+# Define 8080 as the port number
+ENV ASPNETCORE_URLS http://*:8080
+EXPOSE 8080
+
 # Set the entry point for the application
 ENTRYPOINT ["dotnet", "Kurmann.Videoschnitt.Application.dll"]


### PR DESCRIPTION
- Docker-in-Docker zum Devcontainer hinzugefügt
- Wechsel vom internen Port 5024 auf Port 8080, definiert in der `docker-compose.yml`-Datei. Der interne und externe Port sind nun identisch.