### PR TITLE
Engine als alleiniger Message-Verantwortlicher

### DIFF
--- a/src/Application/Handlers/MetadataProcessingHandler.cs
+++ b/src/Application/Handlers/MetadataProcessingHandler.cs
@@ -45,4 +45,23 @@ public class MetadataProcessingHandler(IHubContext<LogHub> logHubContext)
             await logHubContext.Clients.All.SendAsync("ReceiveLogMessage", logMessage);
         }
     }
+
+    public async Task Handle(MediaFilesMetadataProcessingErrorEvent error)
+    {
+        await logHubContext.Clients.All.SendAsync("ReceiveLogMessage", $"Fehler bei der Verarbeitung der Metadaten: {error.Error}");
+    }
+
+    public async Task Handle(MediaFilesMetadataProcessingSuccessEvent message)
+    {
+        await logHubContext.Clients.All.SendAsync("ReceiveLogMessage", "Metadaten erfolgreich verarbeitet.");
+        foreach (var mediaFile in message.MediaFiles)
+        {
+            await logHubContext.Clients.All.SendAsync("ReceiveLogMessage", $"- {mediaFile.Name}");
+        }
+    }
+
+    public async Task Handle(MediaFilesMetadataProcessingStartedEvent _)
+    {
+        await logHubContext.Clients.All.SendAsync("ReceiveLogMessage", "Metadaten-Verarbeitung gestartet.");
+    }
 }

--- a/src/Messages/MediaFilesMessages.cs
+++ b/src/Messages/MediaFilesMessages.cs
@@ -5,3 +5,12 @@ public record MediaFilesForMetadataProcessingFoundEvent(List<FileInfo> MediaFile
 
 // Event um eine Fehlermeldung zu erhalten, wenn die Liste von unterstützten Medien-Dateien nicht abgerufen werden konnte
 public record MediaFilesForMetadataProcessingFoundErrorEvent(string Error);
+
+// Event um eine Fehlermeldung zu erhalten, wenn die Metadaten-Verarbeitung fehlgeschlagen ist
+public record MediaFilesMetadataProcessingErrorEvent(string Error);
+
+// Event um die erfolgreiche Verarbeitung der Metadaten zu erhalten
+public record MediaFilesMetadataProcessingSuccessEvent(List<FileInfo> MediaFiles);
+
+// Event um den Beginn der Metadaten-Verarbeitung zu erhalten
+public record MediaFilesMetadataProcessingStartedEvent();

--- a/src/MetadataProcessor/Services/MediaFileListenerService.cs
+++ b/src/MetadataProcessor/Services/MediaFileListenerService.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Wolverine;
 using CSharpFunctionalExtensions;
 
 namespace Kurmann.Videoschnitt.MetadataProcessor.Services;
@@ -8,14 +7,15 @@ namespace Kurmann.Videoschnitt.MetadataProcessor.Services;
 /// <summary>
 /// Verantwortlich für das Auflisten von unterstützten Medien-Dateien eines Verzeichnisses.
 /// Unterstützte Mediendateien sind Quicktime-Dateien (mov) und MP4-Dateien sowie JPG- und PNG-Dateien, die als Thumbnails verwendet werden können.
-public class MediaFileListenerService(ILogger<MediaFileListenerService> logger, IMessageBus bus, IOptions<MetadataProcessorSettings> settings)
+public class MediaFileListenerService(ILogger<MediaFileListenerService> logger, IOptions<MetadataProcessorSettings> settings)
 {
     private readonly ILogger<MediaFileListenerService> _logger = logger;
-    private IMessageBus _bus = bus;
-    private MetadataProcessorSettings _settings = settings.Value;
+    private readonly MetadataProcessorSettings _settings = settings.Value;
 
     internal Result<List<FileInfo>> GetSupportedMediaFiles()
     {
+        _logger.LogInformation("Unterstützte Medien-Dateien werden gesucht.");
+
         // Interpretiere den Pfad als Verzeichnis
         DirectoryInfo inputDirectory;
         try
@@ -44,11 +44,14 @@ public class MediaFileListenerService(ILogger<MediaFileListenerService> logger, 
         }
 
         // Suche nach Quicktime-Dateien (mov) und MP4-Dateien sowie JPG- und PNG-Dateien
-        return inputDirectory.EnumerateFiles("*", SearchOption.AllDirectories)
+        var files = inputDirectory.EnumerateFiles("*", SearchOption.AllDirectories)
             .Where(file => file.Extension.Equals(".mov", StringComparison.OrdinalIgnoreCase) ||
                             file.Extension.Equals(".mp4", StringComparison.OrdinalIgnoreCase) ||
                             file.Extension.Equals(".m4v", StringComparison.OrdinalIgnoreCase) ||
                             file.Extension.Equals(".jpg", StringComparison.OrdinalIgnoreCase) ||
                             file.Extension.Equals(".png", StringComparison.OrdinalIgnoreCase)).ToList();
+
+        _logger.LogInformation("Es wurden {files.Count} unterstützte Medien-Dateien gefunden.", files.Count);
+        return Result.Success(files);
     }
 }

--- a/src/MetadataProcessor/Services/MetadataProcessingService.cs
+++ b/src/MetadataProcessor/Services/MetadataProcessingService.cs
@@ -1,42 +1,32 @@
 using Microsoft.Extensions.Logging;
-using Kurmann.Videoschnitt.Messages.Metadata;
-using Wolverine;
 using Microsoft.Extensions.Options;
+using CSharpFunctionalExtensions;
+using JasperFx.Core;
 
 namespace Kurmann.Videoschnitt.MetadataProcessor.Services;
 
-public class MetadataProcessingService(ILogger<MetadataProcessingService> logger, IOptions<MetadataProcessorSettings> settings,
-                                       IMessageBus bus, MediaFileListenerService mediaFileListenerService)
+public class MetadataProcessingService(ILogger<MetadataProcessingService> logger, IOptions<MetadataProcessorSettings> settings)
 {
     private readonly ILogger<MetadataProcessingService> _logger = logger;
     private readonly MetadataProcessorSettings _settings = settings.Value;
-    private readonly IMessageBus _bus = bus;
-    private readonly MediaFileListenerService _mediaFileListenerService = mediaFileListenerService;
 
-    public async Task ProcessMetadataAsync()
+    public async Task<Result<List<FileInfo>>> ProcessMetadataAsync(IEnumerable<FileInfo> mediaFiles)
     {
         _logger.LogInformation("Metadatenverarbeitung gestartet.");
 
-        // Liste alle unterstützten Medien-Dateien im Verzeichnis auf
-        var mediaFiles = _mediaFileListenerService.GetSupportedMediaFiles();
-        if (mediaFiles.IsFailure)
-        {
-            _logger.LogError("Fehler beim Auflisten der Medien-Dateien: {Error}", mediaFiles.Error);
-            return;
-        }
-
         // todo: Eigene Logik zur Verarbeitung der Metadaten implementieren
+
+        // Fake processing by waiting 5 seconds
+        await Task.Delay(5000);
     
         _logger.LogInformation("Metadatenverarbeitung abgeschlossen.");
 
         // Todo: Beziehe typisierte Directory-Informationen aus dem MediaFileListenerService
         if (_settings.InputDirectory == null)
         {
-            _logger.LogError("Kein Eingabeverzeichnis konfiguriert.");
-            return;
+            return Result.Failure<List<FileInfo>>("Kein Eingabeverzeichnis konfiguriert.");
         }
 
-        var directory = new DirectoryInfo(_settings.InputDirectory);
-        await _bus.PublishAsync(new MetadataProcessedEvent(directory, mediaFiles.Value));    
+        return mediaFiles.ToList();
     }
 }


### PR DESCRIPTION
- Die Steuerzentralen der jeweiligen Feature-Module, bspw. `MetadataProcessorEngine` sind alleiniger Verantwortlicher für das Versenden von Messages. Vorher konnten auch die von der Steuerzentrale aufgerufenen Services die Nachrichten verschicken.
-  Die Statusnachrichten wurden ausgebaut und zeigen nun die komplette Pseudo-Metadatenverarbeitung an in der Webkonsole (die eigentliche Implementierung folgt im Anschluss)
  ![image](https://github.com/kurmann/videoschnitt/assets/2642655/453ac1ff-76db-40e9-b34a-cb920740fc24)
