### PR TITLE
Einführung von Anwendungsworkflows

### DIFF
--- a/src/Application/Pages/Index.razor
+++ b/src/Application/Pages/Index.razor
@@ -5,12 +5,13 @@
 @using Kurmann.Videoschnitt.Messages.HealthCheck
 @inject NavigationManager Navigation
 @inject Wolverine.IMessageBus bus
+@inject Kurmann.Videoschnitt.Application.Workflows.FinalCutProWorkflow FinalCutProWorkflow
 
 
 <h1>Willkommen bei Kurmann Videoschnitt</h1>
 
 <nav>
-    <a @onclick="async () => await ExecuteMetadataProcessing()">Metadaten-Verarbeitung</a>
+    <a @onclick="async () => await FinalCutProWorkflow.ExecuteAsync()">Metadaten-Verarbeitung</a>
     <a @onclick="async () => await RequestHealthCheck()">Status</a>
     <a href="/swagger">API-Dokumentation</a>
 </nav>

--- a/src/Application/Workflows/FinalCutProWorkflow.cs
+++ b/src/Application/Workflows/FinalCutProWorkflow.cs
@@ -1,11 +1,17 @@
 using CSharpFunctionalExtensions;
+using Kurmann.Videoschnitt.MetadataProcessor;
 
 namespace Kurmann.Videoschnitt.Application.Workflows;
 
-public class FinalCutProWorkflow : IAsyncWorkflow
+public class FinalCutProWorkflow(ILogger<FinalCutProWorkflow> logger, MetadataProcessorEngine engine) : IAsyncWorkflow
 {
-    public Task<Result> ExecuteAsync()
+    public async Task<Result> ExecuteAsync()
     {
-        throw new NotImplementedException();
+        logger.LogInformation("Final Cut Pro Workflow gestartet.");
+
+        await engine.StartAsync();
+
+        logger.LogInformation("Final Cut Pro Workflow beendet.");
+        return Result.Success();
     }
 }

--- a/src/Application/Workflows/FinalCutProWorkflow.cs
+++ b/src/Application/Workflows/FinalCutProWorkflow.cs
@@ -1,0 +1,11 @@
+using CSharpFunctionalExtensions;
+
+namespace Kurmann.Videoschnitt.Application.Workflows;
+
+public class FinalCutProWorkflow : IAsyncWorkflow
+{
+    public Task<Result> ExecuteAsync()
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Application/Workflows/IAsyncValueWorkflow.cs
+++ b/src/Application/Workflows/IAsyncValueWorkflow.cs
@@ -1,0 +1,8 @@
+using CSharpFunctionalExtensions;
+
+namespace Kurmann.Videoschnitt.Application.Workflows;
+
+public interface IAsyncWorkflow<TResult>
+{
+    Task<Result<TResult>> ExecuteAsync();
+}

--- a/src/Application/Workflows/IAsyncWorkflow.cs
+++ b/src/Application/Workflows/IAsyncWorkflow.cs
@@ -1,0 +1,8 @@
+using CSharpFunctionalExtensions;
+
+namespace Kurmann.Videoschnitt.Application.Workflows;
+
+public interface IAsyncWorkflow
+{
+    Task<Result> ExecuteAsync();
+}


### PR DESCRIPTION
- Beginn des Übergangs zu direkten Methodenaufrufe anstelle von Anwendungsmessaging
- Leerer `FinalCutProWorkflow` definiert als erster Workflow
- Zwei Workflow-Interfaces definiert

```csharp
using CSharpFunctionalExtensions;

namespace Kurmann.Videoschnitt.Application.Workflows;

/// <summary>
/// Repräsentiert einen asynchronen Workflow, der einen Wert zurückgibt.
/// </summary>
public interface IAsyncWorkflow<TResult>
{
    Task<Result<TResult>> ExecuteAsync();
}

/// <summary>
/// Repräsentiert einen asynchronen Workflow, der keinen Wert zurückgibt.
/// </summary>
public interface IAsyncWorkflow
{
    Task<Result> ExecuteAsync();
}
```