### PR TITLE
Einführung von Workflow-Callbacks

### DIFF
--- a/src/Application.Workflows/FinalCutProWorkflow.cs
+++ b/src/Application.Workflows/FinalCutProWorkflow.cs
@@ -1,16 +1,31 @@
 using Microsoft.Extensions.Logging;
 using CSharpFunctionalExtensions;
+using Kurmann.Videoschnitt.Application.Workflows.Models;
 using Kurmann.Videoschnitt.MetadataProcessor;
 
 namespace Kurmann.Videoschnitt.Application.Workflows;
 
-public class FinalCutProWorkflow(ILogger<FinalCutProWorkflow> logger, MetadataProcessorEngine engine) : IAsyncWorkflow
+public class FinalCutProWorkflow(ILogger<FinalCutProWorkflow> logger, MetadataProcessorEngine metadataProcessorEngine) : IAsyncWorkflow
 {
-    public async Task<Result> ExecuteAsync()
+    public async Task<Result> ExecuteAsync(Action<StatusUpdate> statusCallback)
     {
         logger.LogInformation("Final Cut Pro Workflow gestartet.");
 
-        await engine.StartAsync();
+        await metadataProcessorEngine.StartAsync();
+
+        // Erste Statusaktualisierung
+        statusCallback(new StatusUpdate("Processing started"));
+
+        // Simuliere einen Verarbeitungsschritt
+        await Task.Delay(1000); // Simuliert eine asynchrone Arbeit
+        statusCallback(new StatusUpdate("Step 1 completed"));
+
+        // Simuliere einen weiteren Verarbeitungsschritt
+        await Task.Delay(1000); // Simuliert eine asynchrone Arbeit
+        statusCallback(new StatusUpdate("Step 2 completed"));
+
+        // Abschließende Statusaktualisierung
+        statusCallback(new StatusUpdate("Processing completed"));
 
         logger.LogInformation("Final Cut Pro Workflow beendet.");
         return Result.Success();

--- a/src/Application.Workflows/IAsyncValueWorkflow.cs
+++ b/src/Application.Workflows/IAsyncValueWorkflow.cs
@@ -1,4 +1,5 @@
 using CSharpFunctionalExtensions;
+using Kurmann.Videoschnitt.Application.Workflows.Models;
 
 namespace Kurmann.Videoschnitt.Application.Workflows;
 
@@ -7,5 +8,5 @@ namespace Kurmann.Videoschnitt.Application.Workflows;
 /// </summary>
 public interface IAsyncWorkflow<TResult>
 {
-    Task<Result<TResult>> ExecuteAsync();
+    Task<Result<TResult>> ExecuteAsync(Action<StatusUpdate> statusCallback);
 }

--- a/src/Application.Workflows/IAsyncWorkflow.cs
+++ b/src/Application.Workflows/IAsyncWorkflow.cs
@@ -1,4 +1,5 @@
 using CSharpFunctionalExtensions;
+using Kurmann.Videoschnitt.Application.Workflows.Models;
 
 namespace Kurmann.Videoschnitt.Application.Workflows;
 
@@ -7,5 +8,5 @@ namespace Kurmann.Videoschnitt.Application.Workflows;
 /// </summary>
 public interface IAsyncWorkflow
 {
-    Task<Result> ExecuteAsync();
+    Task<Result> ExecuteAsync(Action<StatusUpdate> statusCallback);
 }

--- a/src/Application.Workflows/Models/StatusUpdate.cs
+++ b/src/Application.Workflows/Models/StatusUpdate.cs
@@ -1,0 +1,3 @@
+namespace Kurmann.Videoschnitt.Application.Workflows.Models;
+
+public record StatusUpdate(string Message);

--- a/src/Application.Workflows/Models/WorkflowStatusUpdate.cs
+++ b/src/Application.Workflows/Models/WorkflowStatusUpdate.cs
@@ -1,3 +1,0 @@
-namespace Kurmann.Videoschnitt.Application.Workflows;
-
-public record WorkflowStatusUpdate(string Message, int Progress, bool IsError = false);

--- a/src/Application/Pages/Index.razor
+++ b/src/Application/Pages/Index.razor
@@ -11,7 +11,7 @@
 <h1>Willkommen bei Kurmann Videoschnitt</h1>
 
 <nav>
-    <a @onclick="async () => await FinalCutProWorkflow.ExecuteAsync()">Metadaten-Verarbeitung</a>
+    <a @onclick="async () => await ExecuteMetadataProcessing()">Metadaten-Verarbeitung</a>
     <a @onclick="async () => await RequestHealthCheck()">Status</a>
     <a href="/swagger">API-Dokumentation</a>
 </nav>
@@ -56,9 +56,9 @@
 
     private async Task ExecuteMetadataProcessing()
     {
-        // todo: send message to server)
-        await bus.SendAsync(new ProcessMetadataRequest());
-        StateHasChanged();
+        await FinalCutProWorkflow.ExecuteAsync(
+            statusUpdate => logs.Add(statusUpdate.Message)
+        );
     }
 
     private async Task RequestHealthCheck()


### PR DESCRIPTION
Workflows können Status über Callbacks zurückgeben

#### Beispiel

##### Aufruf

```csharp
private async Task ExecuteMetadataProcessing()
{
    await FinalCutProWorkflow.ExecuteAsync(
        statusUpdate => logs.Add(statusUpdate.Message)
    );
}
```

##### Implementierung

```csharp
public async Task<Result> ExecuteAsync(Action<StatusUpdate> statusCallback)
{
    logger.LogInformation("Final Cut Pro Workflow gestartet.");

    await metadataProcessorEngine.StartAsync();

    // Erste Statusaktualisierung
    statusCallback(new StatusUpdate("Processing started"));

    // Simuliere einen Verarbeitungsschritt
    await Task.Delay(1000); // Simuliert eine asynchrone Arbeit
    statusCallback(new StatusUpdate("Step 1 completed"));

    // Simuliere einen weiteren Verarbeitungsschritt
    await Task.Delay(1000); // Simuliert eine asynchrone Arbeit
    statusCallback(new StatusUpdate("Step 2 completed"));

    // Abschließende Statusaktualisierung
    statusCallback(new StatusUpdate("Processing completed"));

    logger.LogInformation("Final Cut Pro Workflow beendet.");
    return Result.Success();
}
```

#### Interfaces

```csharp
public interface IAsyncWorkflow<TResult>
{
    Task<Result<TResult>> ExecuteAsync(Action<StatusUpdate> statusCallback);
}

public interface IAsyncWorkflow
{
    Task<Result> ExecuteAsync(Action<StatusUpdate> statusCallback);
}
```