### PR TITLE
Einführung von .NET `IProgress<T>`

### DIFF
--- a/src/Application.Workflows/FinalCutProWorkflow.cs
+++ b/src/Application.Workflows/FinalCutProWorkflow.cs
@@ -1,33 +1,27 @@
+using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using CSharpFunctionalExtensions;
-using Kurmann.Videoschnitt.Application.Workflows.Models;
-using Kurmann.Videoschnitt.MetadataProcessor;
 
-namespace Kurmann.Videoschnitt.Application.Workflows;
-
-public class FinalCutProWorkflow(ILogger<FinalCutProWorkflow> logger, MetadataProcessorEngine metadataProcessorEngine) : IAsyncWorkflow
+namespace Kurmann.Videoschnitt.Application.Workflows
 {
-    public async Task<Result> ExecuteAsync(Action<StatusUpdate> statusCallback)
+    public class FinalCutProWorkflow
     {
-        logger.LogInformation("Final Cut Pro Workflow gestartet.");
+        private readonly ILogger<FinalCutProWorkflow> _logger;
 
-        await metadataProcessorEngine.StartAsync();
+        public FinalCutProWorkflow(ILogger<FinalCutProWorkflow> logger) => _logger = logger;
 
-        // Erste Statusaktualisierung
-        statusCallback(new StatusUpdate("Processing started"));
+        public async Task ExecuteAsync(IProgress<string> progress)
+        {
+            progress.Report("Metadata processing started.");
 
-        // Simuliere einen Verarbeitungsschritt
-        await Task.Delay(1000); // Simuliert eine asynchrone Arbeit
-        statusCallback(new StatusUpdate("Step 1 completed"));
+            // Simuliere die Metadatenverarbeitung
+            await Task.Delay(1000);
+            progress.Report("Step 1 completed.");
 
-        // Simuliere einen weiteren Verarbeitungsschritt
-        await Task.Delay(1000); // Simuliert eine asynchrone Arbeit
-        statusCallback(new StatusUpdate("Step 2 completed"));
+            await Task.Delay(1000);
+            progress.Report("Step 2 completed.");
 
-        // Abschließende Statusaktualisierung
-        statusCallback(new StatusUpdate("Processing completed"));
-
-        logger.LogInformation("Final Cut Pro Workflow beendet.");
-        return Result.Success();
+            progress.Report("Metadata processing completed.");
+        }
     }
 }

--- a/src/Application.Workflows/FinalCutProWorkflow.cs
+++ b/src/Application.Workflows/FinalCutProWorkflow.cs
@@ -2,26 +2,25 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
-namespace Kurmann.Videoschnitt.Application.Workflows
+namespace Kurmann.Videoschnitt.Application.Workflows;
+
+public class FinalCutProWorkflow
 {
-    public class FinalCutProWorkflow
+    private readonly ILogger<FinalCutProWorkflow> _logger;
+
+    public FinalCutProWorkflow(ILogger<FinalCutProWorkflow> logger) => _logger = logger;
+
+    public async Task ExecuteAsync(IProgress<string> progress)
     {
-        private readonly ILogger<FinalCutProWorkflow> _logger;
+        progress.Report("Metadata processing started.");
 
-        public FinalCutProWorkflow(ILogger<FinalCutProWorkflow> logger) => _logger = logger;
+        // Simuliere die Metadatenverarbeitung
+        await Task.Delay(1000);
+        progress.Report("Step 1 completed.");
 
-        public async Task ExecuteAsync(IProgress<string> progress)
-        {
-            progress.Report("Metadata processing started.");
+        await Task.Delay(1000);
+        progress.Report("Step 2 completed.");
 
-            // Simuliere die Metadatenverarbeitung
-            await Task.Delay(1000);
-            progress.Report("Step 1 completed.");
-
-            await Task.Delay(1000);
-            progress.Report("Step 2 completed.");
-
-            progress.Report("Metadata processing completed.");
-        }
+        progress.Report("Metadata processing completed.");
     }
 }

--- a/src/Application.Workflows/IAsyncValueWorkflow.cs
+++ b/src/Application.Workflows/IAsyncValueWorkflow.cs
@@ -1,5 +1,4 @@
 using CSharpFunctionalExtensions;
-using Kurmann.Videoschnitt.Application.Workflows.Models;
 
 namespace Kurmann.Videoschnitt.Application.Workflows;
 

--- a/src/Application.Workflows/IAsyncValueWorkflow.cs
+++ b/src/Application.Workflows/IAsyncValueWorkflow.cs
@@ -8,5 +8,5 @@ namespace Kurmann.Videoschnitt.Application.Workflows;
 /// </summary>
 public interface IAsyncWorkflow<TResult>
 {
-    Task<Result<TResult>> ExecuteAsync(Action<StatusUpdate> statusCallback);
+    Task<Result<TResult>> ExecuteAsync(IProgress<string> progress);
 }

--- a/src/Application.Workflows/IAsyncWorkflow.cs
+++ b/src/Application.Workflows/IAsyncWorkflow.cs
@@ -8,5 +8,5 @@ namespace Kurmann.Videoschnitt.Application.Workflows;
 /// </summary>
 public interface IAsyncWorkflow
 {
-    Task<Result> ExecuteAsync(Action<StatusUpdate> statusCallback);
+    Task<Result> ExecuteAsync(IProgress<string> progress);
 }

--- a/src/Application.Workflows/IAsyncWorkflow.cs
+++ b/src/Application.Workflows/IAsyncWorkflow.cs
@@ -1,5 +1,4 @@
 using CSharpFunctionalExtensions;
-using Kurmann.Videoschnitt.Application.Workflows.Models;
 
 namespace Kurmann.Videoschnitt.Application.Workflows;
 

--- a/src/Application.Workflows/Models/StatusUpdate.cs
+++ b/src/Application.Workflows/Models/StatusUpdate.cs
@@ -1,3 +1,0 @@
-namespace Kurmann.Videoschnitt.Application.Workflows.Models;
-
-public record StatusUpdate(string Message);

--- a/src/Application/Pages/Index.razor
+++ b/src/Application/Pages/Index.razor
@@ -7,7 +7,6 @@
 @inject Wolverine.IMessageBus bus
 @inject Kurmann.Videoschnitt.Application.Workflows.FinalCutProWorkflow FinalCutProWorkflow
 
-
 <h1>Willkommen bei Kurmann Videoschnitt</h1>
 
 <nav>
@@ -56,9 +55,13 @@
 
     private async Task ExecuteMetadataProcessing()
     {
-        await FinalCutProWorkflow.ExecuteAsync(
-            statusUpdate => logs.Add(statusUpdate.Message)
-        );
+        var progress = new Progress<string>(statusUpdate =>
+        {
+            logs.Add(statusUpdate);
+            InvokeAsync(StateHasChanged);
+        });
+
+        await FinalCutProWorkflow.ExecuteAsync(progress);
     }
 
     private async Task RequestHealthCheck()


### PR DESCRIPTION
Die Progress-Klasse ersetzt die eigene StatusUpdate-Klasse und somit wird mit .NET Boardmitteln gearbeitet bei der Übermittlung von Statusupdates.

**Beispiel**

```csharp
public async Task ExecuteAsync(IProgress<string> progress)
{
    progress.Report("Metadata processing started.");

    // Simuliere die Metadatenverarbeitung
    await Task.Delay(1000);
    progress.Report("Step 1 completed.");

    await Task.Delay(1000);
    progress.Report("Step 2 completed.");

    progress.Report("Metadata processing completed.");
}
```