### PR TITLE
Konfigurationswerte werden korrekt ausgelesen

### DIFF
--- a/src/MetadataProcessor/MetadataProcessorSettings.cs
+++ b/src/MetadataProcessor/MetadataProcessorSettings.cs
@@ -2,6 +2,8 @@ namespace Kurmann.Videoschnitt.MetadataProcessor;
 
 public class MetadataProcessorSettings
 {
+    public const string SectionName = "MetadataProcessing";
+
     public string? InputDirectory { get; set; }
 
     public MediaSetSettings? MediaSetSettings { get; set; } = new MediaSetSettings();

--- a/src/MetadataProcessor/ServiceCollectionExtensions.cs
+++ b/src/MetadataProcessor/ServiceCollectionExtensions.cs
@@ -9,7 +9,8 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddMetadataProcessor(this IServiceCollection services, IConfiguration configuration)
     {   
         // Add configuration sources
-        services.Configure<MetadataProcessorSettings>(options => configuration.GetSection("MetadataProcessor").Bind(options));
+        var section = configuration.GetSection(MetadataProcessorSettings.SectionName);
+        services.Configure<MetadataProcessorSettings>(options => section.Bind(options));
 
         // Register MetadataProcessingService
         services.AddSingleton<MetadataProcessingService>();


### PR DESCRIPTION
Aufgrund einer falschen Benennung der SectionName ("MetadataProcessing" statt "MetadataProcessor") wurden u.a. den Eingabepfad für die Metadatenbearbeitung nicht ausgelesen.

Der SectionName wurde nun direkt in den Settings-Klasse integriert als Konstante.

```csharp
public const string SectionName = "MetadataProcessing";
```