### PR TITLE
Metadaten-Auslesemechanismus

### DIFF
--- a/src/Application/Components/MainNavigation.razor
+++ b/src/Application/Components/MainNavigation.razor
@@ -14,17 +14,17 @@
     [Parameter]
     public EventCallback<string> OnLogAdded { get; set; }
 
-    private void ExecuteMetadataProcessing()
+    private async Task ExecuteMetadataProcessing()
     {
         var progress = new Progress<string>(async statusUpdate =>
         {
             await OnLogAdded.InvokeAsync(statusUpdate);
         });
 
-        var result = FinalCutProWorkflow.Execute(progress);
+        var result = await FinalCutProWorkflow.ExecuteAsync(progress);
         if (result.IsFailure)
         {
-            OnLogAdded.InvokeAsync(result.Error);
+            await OnLogAdded.InvokeAsync(result.Error);
         }
     }
 

--- a/src/Application/Components/MainNavigation.razor
+++ b/src/Application/Components/MainNavigation.razor
@@ -5,7 +5,7 @@
 @inject Kurmann.Videoschnitt.Workflows.HealthCheckWorkflow HealthCheckWorkflow
 
 <nav>
-    <a @onclick="async () => await ExecuteMetadataProcessing()">Metadaten-Verarbeitung</a>
+    <a @onclick="ExecuteMetadataProcessing">Metadaten-Verarbeitung</a>
     <a @onclick="ExecuteHealthCheck">Status</a>
     <a href="/swagger">API-Dokumentation</a>
 </nav>
@@ -14,17 +14,17 @@
     [Parameter]
     public EventCallback<string> OnLogAdded { get; set; }
 
-    private async Task ExecuteMetadataProcessing()
+    private void ExecuteMetadataProcessing()
     {
         var progress = new Progress<string>(async statusUpdate =>
         {
             await OnLogAdded.InvokeAsync(statusUpdate);
         });
 
-        var result = await FinalCutProWorkflow.ExecuteAsync(progress);
+        var result = FinalCutProWorkflow.Execute(progress);
         if (result.IsFailure)
         {
-            await OnLogAdded.InvokeAsync(result.Error);
+            OnLogAdded.InvokeAsync(result.Error);
         }
     }
 

--- a/src/MetadataProcessor/Entities/FFmpegMetadata.cs
+++ b/src/MetadataProcessor/Entities/FFmpegMetadata.cs
@@ -1,0 +1,80 @@
+using CSharpFunctionalExtensions;
+
+namespace Kurmann.Videoschnitt.MetadataProcessor.Entities;
+
+public class FFmpegMetadata
+{
+    public string? MajorBrand { get; }
+    public string? MinorVersion { get; }
+    public string? CompatibleBrands { get; }
+    public string? Copyright { get; }
+    public DateOnly? Date { get; }
+    public string? Keywords { get; }
+    public string? Title { get; }
+    public string? Album { get; }
+    public string? Artist { get; }
+    public string? Author { get; }
+    public string? DisplayName { get; }
+    public DateOnly? CreationDate { get; }
+    public string? Description { get; }
+    public string? Encoder { get; }
+
+    private FFmpegMetadata(Dictionary<string, string> metadata)
+    {
+        MajorBrand = metadata.GetValueOrDefault("major_brand");
+        MinorVersion = metadata.GetValueOrDefault("minor_version");
+        CompatibleBrands = metadata.GetValueOrDefault("compatible_brands");
+        Copyright = metadata.GetValueOrDefault("com.apple.quicktime.copyright");
+        Date = ParseDate(metadata.GetValueOrDefault("date"));
+        Keywords = metadata.GetValueOrDefault("keywords");
+        Title = metadata.GetValueOrDefault("title");
+        Album = metadata.GetValueOrDefault("album");
+        Artist = metadata.GetValueOrDefault("artist");
+        Author = metadata.GetValueOrDefault("com.apple.quicktime.author");
+        DisplayName = metadata.GetValueOrDefault("com.apple.quicktime.displayname");
+        CreationDate = ParseDate(metadata.GetValueOrDefault("com.apple.quicktime.creationdate"));
+        Description = metadata.GetValueOrDefault("com.apple.quicktime.description");
+        Encoder = metadata.GetValueOrDefault("encoder");
+    }
+
+    public static Result<FFmpegMetadata> Create(string rawString)
+    {
+        // Prüfen, ob die Zeichenfolge leer ist
+        if (string.IsNullOrWhiteSpace(rawString))
+        {
+            return Result.Failure<FFmpegMetadata>("The FFMpeg raw string is empty.");
+        }
+
+        var metadata = new Dictionary<string, string>();
+
+        try
+        {
+            foreach (var line in rawString.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (line.StartsWith(";") || string.IsNullOrWhiteSpace(line)) continue;
+
+                var parts = line.Split('=', 2);
+                if (parts.Length == 2)
+                {
+                    metadata[parts[0].Trim()] = parts[1].Trim();
+                }
+            }
+        }
+        catch (System.Exception ex)
+        {
+            return Result.Failure<FFmpegMetadata>($"Error while parsing FFmpeg metadata: {ex.Message}");
+        }
+
+        return new FFmpegMetadata(metadata);
+    }
+
+    private static DateOnly? ParseDate(string? dateString)
+    {
+        if (DateOnly.TryParse(dateString, out var date))
+        {
+            return date;
+        }
+
+        return null;
+    }
+}

--- a/src/MetadataProcessor/Entities/MediasetCollection.cs
+++ b/src/MetadataProcessor/Entities/MediasetCollection.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
 namespace Kurmann.Videoschnitt.MetadataProcessor.Entities;
 
 /// <summary>
@@ -23,10 +18,12 @@ namespace Kurmann.Videoschnitt.MetadataProcessor.Entities;
 public class MediasetCollection
 {
     public List<FileInfo> IgnoredFiles { get; }
+    public List<MediaSet> Mediasets { get; }
 
-    private MediasetCollection(List<FileInfo> ignoredFiles)
+    private MediasetCollection(List<FileInfo> ignoredFile, List<MediaSet> mediasets)
     {
-        IgnoredFiles = ignoredFiles;
+        IgnoredFiles = ignoredFile;
+        Mediasets = mediasets;
     }
 
     public static MediasetCollection Create(IEnumerable<FileInfo> mediaFiles,
@@ -66,7 +63,7 @@ public class MediasetCollection
             mediasets.Add(mediaset);
         }
 
-        return new MediasetCollection(filesWithoutLeadingIsoDate);
+        return new MediasetCollection(filesWithoutLeadingIsoDate, mediasets);
     }
 
     // Gib eine Liste von Medien-Dateien zurück, die ohne ISO-Datum und nachfolgendem Leerzeichen beginnen
@@ -115,11 +112,21 @@ public class MediasetCollection
     }
 }
 
-internal record MediaSet
+public record MediaSet
 {
     public string? Name { get; set; }
 
     internal List<FileInfo> Videos { get; set; } = new List<FileInfo>();
 
     internal List<FileInfo> Images { get; set; } = new List<FileInfo>();
+
+    /// <summary>
+    /// Filtere nach QuickTime MOV Dateien und berücksichtige Gross- und Kleinschreibung (.mov und .MOV)
+    /// </summary>
+    public List<FileInfo> QuickTimeVideos => Videos.Where(v => v.Extension.Equals(".mov", StringComparison.OrdinalIgnoreCase)).ToList();
+
+    /// <summary>
+    /// Filtere nach MP4 Dateien und berücksichtige Gross- und Kleinschreibung (.mp4 und .MP4 sowie .m4v und .M4V)
+    /// </summary>
+    public List<FileInfo> Mp4Videos => Videos.Where(v => v.Extension.Equals(".mp4", StringComparison.OrdinalIgnoreCase) || v.Extension.Equals(".m4v", StringComparison.OrdinalIgnoreCase)).ToList();
 }

--- a/src/MetadataProcessor/MetadataProcessorEngine.cs
+++ b/src/MetadataProcessor/MetadataProcessorEngine.cs
@@ -25,7 +25,7 @@ namespace Kurmann.Videoschnitt.MetadataProcessor
             _ffmpegMetadataService = ffmpegMetadataService;
         }
 
-        public Result Start(IProgress<string> progress)
+        public async Task<Result> Start(IProgress<string> progress)
         {
             progress.Report("Steuereinheit für die Metadaten-Verarbeitung gestartet.");
 
@@ -53,7 +53,7 @@ namespace Kurmann.Videoschnitt.MetadataProcessor
                                                       _settings.FileTypeSettings.SupportedImageExtensions);
 
             // Verarbeite alle Mediensets
-            var result = Process(mediaSets, progress);
+            var result = await Process(mediaSets, progress);
             if (result.IsFailure)
             {
                 return Result.Failure($"Fehler bei der Verarbeitung der Mediensets: {result.Error}");
@@ -65,7 +65,7 @@ namespace Kurmann.Videoschnitt.MetadataProcessor
         /// <summary>
         /// Verarbeitet die Metadaten eines Mediensets.
         /// </summary>
-        private Result Process(MediasetCollection mediasetCollection, IProgress<string> progress)
+        private async Task<Result> Process(MediasetCollection mediasetCollection, IProgress<string> progress)
         {
             if (mediasetCollection?.Mediasets == null)
             {
@@ -76,7 +76,7 @@ namespace Kurmann.Videoschnitt.MetadataProcessor
             foreach (var mediaSet in mediasetCollection.Mediasets)
             {
                 // Verarbeite das Medienset
-                var result = Process(mediaSet, progress);
+                var result = await Process(mediaSet, progress);
                 if (result.IsFailure)
                 {
                     return Result.Failure($"Fehler bei der Verarbeitung des Mediensets {mediaSet.Name}: {result.Error}");
@@ -87,7 +87,7 @@ namespace Kurmann.Videoschnitt.MetadataProcessor
             return Result.Success();
         }
 
-        private Result Process(MediaSet mediaSet, IProgress<string> progress)
+        private async Task<Result> Process(MediaSet mediaSet, IProgress<string> progress)
         {
             // Nimm die zuerst gefundene QuickTime MOV Datei als Referenz für die Metadaten-Verarbeitung
             var referenceMediaFile = mediaSet.QuickTimeVideos.FirstOrDefault();
@@ -100,7 +100,7 @@ namespace Kurmann.Videoschnitt.MetadataProcessor
             progress.Report("Beginne mit der Verarbeitung der Metadaten.");
 
             // Lies die Metadaten der Referenzdatei aus
-            var metadataResult = _ffmpegMetadataService.GetFFmpegMetadata(referenceMediaFile.FullName);
+            var metadataResult = await _ffmpegMetadataService.GetFFmpegMetadataAsync(referenceMediaFile.FullName);
             if (metadataResult.IsFailure)
             {
                 return Result.Failure($"Fehler beim Auslesen der Metadaten der Referenzdatei {referenceMediaFile.Name}: {metadataResult.Error}");

--- a/src/MetadataProcessor/MetadataProcessorEngine.cs
+++ b/src/MetadataProcessor/MetadataProcessorEngine.cs
@@ -14,16 +14,18 @@ namespace Kurmann.Videoschnitt.MetadataProcessor
         private readonly MetadataProcessorSettings _settings;
         private readonly MediaFileListenerService _mediaFileListenerService;
         private readonly MetadataProcessingService _metadataProcessingService;
+        private readonly FFmpegMetadataService _ffmpegMetadataService;
 
         public MetadataProcessorEngine(IOptions<MetadataProcessorSettings> settings, ILogger<MetadataProcessorEngine> logger,
-            MediaFileListenerService mediaFileListenerService, MetadataProcessingService metadataProcessingService)
+            MediaFileListenerService mediaFileListenerService, MetadataProcessingService metadataProcessingService, FFmpegMetadataService ffmpegMetadataService)
         {
             _settings = settings.Value;
             _mediaFileListenerService = mediaFileListenerService;
             _metadataProcessingService = metadataProcessingService;
+            _ffmpegMetadataService = ffmpegMetadataService;
         }
 
-        public async Task<Result> StartAsync(IProgress<string> progress)
+        public Result Start(IProgress<string> progress)
         {
             progress.Report("Steuereinheit für die Metadaten-Verarbeitung gestartet.");
 
@@ -50,19 +52,66 @@ namespace Kurmann.Videoschnitt.MetadataProcessor
                                                       _settings.FileTypeSettings.SupportedVideoExtensions,
                                                       _settings.FileTypeSettings.SupportedImageExtensions);
 
+            // Verarbeite alle Mediensets
+            var result = Process(mediaSets, progress);
+            if (result.IsFailure)
+            {
+                return Result.Failure($"Fehler bei der Verarbeitung der Mediensets: {result.Error}");
+            }
+
+            return Result.Success();
+        }
+
+        /// <summary>
+        /// Verarbeitet die Metadaten eines Mediensets.
+        /// </summary>
+        private Result Process(MediasetCollection mediasetCollection, IProgress<string> progress)
+        {
+            if (mediasetCollection?.Mediasets == null)
+            {
+                return Result.Failure("Keine Mediensets gefunden.");
+            }
+
+            // Iteriere über alle Mediensets
+            foreach (var mediaSet in mediasetCollection.Mediasets)
+            {
+                // Verarbeite das Medienset
+                var result = Process(mediaSet, progress);
+                if (result.IsFailure)
+                {
+                    return Result.Failure($"Fehler bei der Verarbeitung des Mediensets {mediaSet.Name}: {result.Error}");
+                }
+                progress.Report($"Medienset {mediaSet.Name} erfolgreich verarbeitet.");
+            }
+
+            return Result.Success();
+        }
+
+        private Result Process(MediaSet mediaSet, IProgress<string> progress)
+        {
+            // Nimm die zuerst gefundene QuickTime MOV Datei als Referenz für die Metadaten-Verarbeitung
+            var referenceMediaFile = mediaSet.QuickTimeVideos.FirstOrDefault();
+            if (referenceMediaFile == null)
+            {
+                return Result.Failure($"Keine QuickTime MOV Datei gefunden im Medienset {mediaSet.Name} um die Metadaten auszulesen.");
+            }
+
             // Informiere über den Beginn der Metadaten-Verarbeitung
             progress.Report("Beginne mit der Verarbeitung der Metadaten.");
 
-            // Verarbeite die Metadaten der Medien-Dateien.
-            var processedMediaFiles = await _metadataProcessingService.ProcessMetadataAsync(mediaFiles.Value);
-            if (processedMediaFiles.IsFailure)
+            // Lies die Metadaten der Referenzdatei aus
+            var metadataResult = _ffmpegMetadataService.GetFFmpegMetadata(referenceMediaFile.FullName);
+            if (metadataResult.IsFailure)
             {
-                progress.Report("Fehler bei der Verarbeitung der Metadaten.");
-                return Result.Failure(processedMediaFiles.Error);
+                return Result.Failure($"Fehler beim Auslesen der Metadaten der Referenzdatei {referenceMediaFile.Name}: {metadataResult.Error}");
             }
 
             // Informiere über die erfolgreiche Verarbeitung der Metadaten
             progress.Report("Metadaten erfolgreich verarbeitet.");
+
+            // Informiere über die Metadaten der Referenzdatei
+            progress.Report(metadataResult.Value);
+
             return Result.Success();
         }
     }

--- a/src/MetadataProcessor/ServiceCollectionExtensions.cs
+++ b/src/MetadataProcessor/ServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<MetadataProcessorEngine>();
         services.AddSingleton<MediaFileListenerService>();
         services.AddSingleton<FFmpegMetadataService>();
+        services.AddSingleton<CommandExecutorService>();
 
         return services;
     }

--- a/src/MetadataProcessor/ServiceCollectionExtensions.cs
+++ b/src/MetadataProcessor/ServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<MetadataProcessingService>();
         services.AddSingleton<MetadataProcessorEngine>();
         services.AddSingleton<MediaFileListenerService>();
+        services.AddSingleton<FFmpegMetadataService>();
 
         return services;
     }

--- a/src/MetadataProcessor/Services/CommandExecutorService.cs
+++ b/src/MetadataProcessor/Services/CommandExecutorService.cs
@@ -1,0 +1,52 @@
+using System.Diagnostics;
+using System.Text;
+using CSharpFunctionalExtensions;
+using Microsoft.Extensions.Logging;
+
+namespace Kurmann.Videoschnitt.MetadataProcessor.Services;
+
+public class CommandExecutorService
+{
+    private readonly ILogger<CommandExecutorService> _logger;
+
+    public CommandExecutorService(ILogger<CommandExecutorService> logger) => _logger = logger;
+
+    /// <summary>
+    /// Führt den externen Process aus und retourniert alle Rückgabewerte.
+    /// Loggt die Rückgabewerte laufend.
+    /// </summary>
+    /// <param name="arguments"></param>
+    /// <returns></returns>
+    public async Task<Result<List<string>>> ExecuteCommandAsync(string commandPath, string arguments)
+    {
+        _logger.LogInformation($"Executing command: {commandPath} {arguments}");
+
+        var psi = new ProcessStartInfo(commandPath, arguments)
+        {
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            StandardOutputEncoding = Encoding.UTF8
+        };
+
+        var lines = new List<string>();
+
+        using (var process = new Process { StartInfo = psi, EnableRaisingEvents = true })
+        {
+            process.OutputDataReceived += (sender, e) =>
+            {
+                if (e.Data != null)
+                {
+                    _logger.LogInformation(e.Data);
+                    lines.Add(e.Data);
+                }
+            };
+
+            process.Start();
+            process.BeginOutputReadLine();
+            await process.WaitForExitAsync();
+        }
+
+        return Result.Success(lines);
+    }
+}

--- a/src/MetadataProcessor/Services/FFMpegMetadataService.cs
+++ b/src/MetadataProcessor/Services/FFMpegMetadataService.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics;
+using CSharpFunctionalExtensions;
+
+namespace Kurmann.Videoschnitt.MetadataProcessor.Services;
+
+public class FFmpegMetadataService
+{
+    public Result<string> GetFFmpegMetadata(string filePath)
+    {
+        try
+        {
+            var process = new Process()
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "/bin/bash",
+                    Arguments = $"-c \"ffmpeg -i '{filePath}' -f ffmetadata -\"",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                }
+            };
+            process.Start();
+            string result = process.StandardOutput.ReadToEnd();
+            string error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            if (!string.IsNullOrWhiteSpace(error))
+            {
+                return Result.Failure<string>(error);
+            }
+
+            return Result.Success(result);
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure<string>(ex.Message);
+        }
+    }
+}

--- a/src/MetadataProcessor/Services/FFMpegMetadataService.cs
+++ b/src/MetadataProcessor/Services/FFMpegMetadataService.cs
@@ -17,7 +17,7 @@ public class FFmpegMetadataService
     public async Task<Result<string>> GetFFmpegMetadataAsync(string filePath)
     {
         var arguments = $"-i \"{filePath}\" -f ffmetadata -";
-        var result = await _executorService.ExecuteCommandAsync("/usr/bin/ffmpeg", arguments);
+        var result = await _executorService.ExecuteCommandAsync("ffmpeg", arguments);
 
         if (result.IsSuccess)
         {

--- a/src/Workflows/FinalCutProWorkflow.cs
+++ b/src/Workflows/FinalCutProWorkflow.cs
@@ -4,7 +4,7 @@ using CSharpFunctionalExtensions;
 
 namespace Kurmann.Videoschnitt.Workflows;
 
-public class FinalCutProWorkflow : IWorkflow
+public class FinalCutProWorkflow : IAsyncWorkflow
 {
     private readonly ILogger<FinalCutProWorkflow> _logger;
     private readonly MetadataProcessorEngine _metadataProcessorEngine;
@@ -15,11 +15,11 @@ public class FinalCutProWorkflow : IWorkflow
         _metadataProcessorEngine = metadataProcessorEngine;
     }
 
-    public Result Execute(IProgress<string> progress)
+    public async Task<Result> ExecuteAsync(IProgress<string> progress)
     {
         progress.Report("Final Cut Pro Workflow gestartet.");
 
-        var result = _metadataProcessorEngine.Start(progress);
+        var result = await _metadataProcessorEngine.Start(progress);
         if (result.IsFailure)
         {
             return Result.Failure($"Fehler beim Ausführen des Final Cut Pro Workflows: {result.Error}");

--- a/src/Workflows/FinalCutProWorkflow.cs
+++ b/src/Workflows/FinalCutProWorkflow.cs
@@ -4,7 +4,7 @@ using CSharpFunctionalExtensions;
 
 namespace Kurmann.Videoschnitt.Workflows;
 
-public class FinalCutProWorkflow : IAsyncWorkflow
+public class FinalCutProWorkflow : IWorkflow
 {
     private readonly ILogger<FinalCutProWorkflow> _logger;
     private readonly MetadataProcessorEngine _metadataProcessorEngine;
@@ -15,11 +15,11 @@ public class FinalCutProWorkflow : IAsyncWorkflow
         _metadataProcessorEngine = metadataProcessorEngine;
     }
 
-    public async Task<Result> ExecuteAsync(IProgress<string> progress)
+    public Result Execute(IProgress<string> progress)
     {
         progress.Report("Final Cut Pro Workflow gestartet.");
 
-        var result = await _metadataProcessorEngine.StartAsync(progress);
+        var result = _metadataProcessorEngine.Start(progress);
         if (result.IsFailure)
         {
             return Result.Failure($"Fehler beim Ausführen des Final Cut Pro Workflows: {result.Error}");


### PR DESCRIPTION
Der Mechanismus für die Metadaten wurden umgesetzt. In der Konsole werden die Test-Metadaten innerhalb des Containers ausgegeben.

![image](https://github.com/kurmann/videoschnitt/assets/2642655/5a0cd47f-33c3-4eaf-b8cb-b655b8c1a2d0)
