### PR TITLE
Eingabeverzeichnis wird ausgegeben

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,7 @@ services:
     build: .
     container_name: videoschnitt
     volumes:
-      - ${LOCAL_MEDIA_LIBRARY_PATH}:/media/library:rw
-      - ${METADATA_PROCESSING_DIRECTORY}:/media/metadata-processing:rw
+      - ${MetadataProcessing__InputDirectory}:/media/metadata-processing:rw
     ports:
       - "8080:8080"
     env_file:
@@ -12,5 +11,4 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
       - PORT=8080
-      - LOCAL_MEDIA_LIBRARY_PATH=/media/library
-      - METADATA_PROCESSING_DIRECTORY=/media/metadata-processing
+      - MetadataProcessing__InputDirectory=/media/metadata-processing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,13 @@ services:
     container_name: videoschnitt
     volumes:
       - ${LOCAL_MEDIA_LIBRARY_PATH}:/media/library:rw
+      - ${METADATA_PROCESSING_DIRECTORY}:/media/metadata-processing:rw
     ports:
-      - "8080:5024"
+      - "8080:8080"
     env_file:
       - .env
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
-      - PORT=5024 # Hier den Port eintragen, auf dem der Server laufen soll (Standard: 5024)
+      - PORT=8080
       - LOCAL_MEDIA_LIBRARY_PATH=/media/library
+      - METADATA_PROCESSING_DIRECTORY=/media/metadata-processing

--- a/src/MetadataProcessor/MetadataProcessorEngine.cs
+++ b/src/MetadataProcessor/MetadataProcessorEngine.cs
@@ -29,6 +29,15 @@ namespace Kurmann.Videoschnitt.MetadataProcessor
         {
             progress.Report("Steuereinheit für die Metadaten-Verarbeitung gestartet.");
 
+            // Prüfe ob die Einstellungen korrekt geladen wurden
+            if (_settings.InputDirectory == null)
+            {
+                return Result.Failure("Kein Eingabeverzeichnis konfiguriert. Wenn Umgebungsvariablen verwendet werden, sollte der Name der Umgebungsvariable 'MetadataProcessing__InputDirectory' lauten.");
+            }
+
+            // Informiere über das Eingabeverzeichnis
+            progress.Report($"Eingabeverzeichnis: {_settings.InputDirectory}");
+
             // Liste alle unterstützten Medien-Dateien im Verzeichnis auf
             var mediaFiles = _mediaFileListenerService.GetSupportedMediaFiles();
             if (mediaFiles.IsFailure)


### PR DESCRIPTION
Eine Prüfroutine gibt den Inhalt der Umgebungsvariable `MetadataProcessing__InputDirectory` aus, die auf ein lokales Verzeichnis verweist, das als Volume in den Docker-Container gemappt wird