### PR TITLE
Findet QuickTime-Variante MPEG-4-Datei

### DIFF
--- a/src/MetadataProcessor/Entities/SupportedMediaTypes/CoverArtImage.cs
+++ b/src/MetadataProcessor/Entities/SupportedMediaTypes/CoverArtImage.cs
@@ -1,0 +1,21 @@
+using CSharpFunctionalExtensions;
+
+namespace Kurmann.Videoschnitt.MetadataProcessor.Entities.SupportedMediaTypes;
+
+public record CoverArtImage : ISupportedMediaType
+{
+    public FileInfo FileInfo { get; }
+
+    private CoverArtImage(FileInfo fileInfo) => FileInfo = fileInfo;
+
+    public static Result<CoverArtImage> Create(FileInfo fileInfo)
+    {
+        // Prüfe, einschliesslich Gross- und Kleinschreibung (InvariantCultureIgnoreCase), ob die Dateiendung .jpg, .jpeg oder .png ist
+        if (fileInfo.Extension.Equals(".jpg", StringComparison.InvariantCultureIgnoreCase) || fileInfo.Extension.Equals(".jpeg", StringComparison.InvariantCultureIgnoreCase) || fileInfo.Extension.Equals(".png", StringComparison.InvariantCultureIgnoreCase))
+        {
+            return new CoverArtImage(fileInfo);
+        }
+
+        return Result.Failure<CoverArtImage>($"File {fileInfo.FullName} is not a supported cover art image.");
+    }
+}

--- a/src/MetadataProcessor/Entities/SupportedMediaTypes/ISupportedMediaType.cs
+++ b/src/MetadataProcessor/Entities/SupportedMediaTypes/ISupportedMediaType.cs
@@ -1,0 +1,6 @@
+namespace Kurmann.Videoschnitt.MetadataProcessor.Entities.SupportedMediaTypes;
+
+public interface ISupportedMediaType
+{
+    FileInfo FileInfo { get; }
+}

--- a/src/MetadataProcessor/Entities/SupportedMediaTypes/Mpeg4Video.cs
+++ b/src/MetadataProcessor/Entities/SupportedMediaTypes/Mpeg4Video.cs
@@ -1,0 +1,21 @@
+using CSharpFunctionalExtensions;
+
+namespace Kurmann.Videoschnitt.MetadataProcessor.Entities.SupportedMediaTypes;
+
+public class Mpeg4Video : ISupportedMediaType
+{
+    public FileInfo FileInfo { get; }
+
+    private Mpeg4Video(FileInfo fileInfo) => FileInfo = fileInfo;
+
+    public static Result<Mpeg4Video> Create(FileInfo fileInfo)
+    {
+        // Prüfe, einschliesslich Gross- und Kleinschreibung (InvariantCultureIgnoreCase), ob die Dateiendung .mp4 oder .m4v ist
+        if (fileInfo.Extension.Equals(".mp4", StringComparison.InvariantCultureIgnoreCase) || fileInfo.Extension.Equals(".m4v", StringComparison.InvariantCultureIgnoreCase))
+        {
+            return new Mpeg4Video(fileInfo);
+        }
+
+        return Result.Failure<Mpeg4Video>($"File {fileInfo.FullName} is not a supported MPEG-4 video.");
+    }
+}

--- a/src/MetadataProcessor/Entities/SupportedMediaTypes/QuickTimeMovie.cs
+++ b/src/MetadataProcessor/Entities/SupportedMediaTypes/QuickTimeMovie.cs
@@ -1,0 +1,21 @@
+using CSharpFunctionalExtensions;
+
+namespace Kurmann.Videoschnitt.MetadataProcessor.Entities.SupportedMediaTypes;
+
+public class QuickTimeMovie : ISupportedMediaType
+{
+    public FileInfo FileInfo { get; }
+
+    private QuickTimeMovie(FileInfo fileInfo) => FileInfo = fileInfo;
+
+    public static Result<QuickTimeMovie> Create(FileInfo fileInfo)
+    {
+        // Prüfe, einschliesslich Gross- und Kleinschreibung (InvariantCultureIgnoreCase), ob die Dateiendung .mov oder .qt ist
+        if (fileInfo.Extension.Equals(".mov", StringComparison.InvariantCultureIgnoreCase) || fileInfo.Extension.Equals(".qt", StringComparison.InvariantCultureIgnoreCase))
+        {
+            return new QuickTimeMovie(fileInfo);
+        }
+
+        return Result.Failure<QuickTimeMovie>($"File {fileInfo.FullName} is not a supported QuickTime movie.");
+    }
+}

--- a/src/MetadataProcessor/MetadataProcessorEngine.cs
+++ b/src/MetadataProcessor/MetadataProcessorEngine.cs
@@ -15,14 +15,17 @@ namespace Kurmann.Videoschnitt.MetadataProcessor
         private readonly MediaFileListenerService _mediaFileListenerService;
         private readonly MetadataProcessingService _metadataProcessingService;
         private readonly FFmpegMetadataService _ffmpegMetadataService;
+        private readonly MediaTypeDetectorService _mediaTypeDetectorService;
 
         public MetadataProcessorEngine(IOptions<MetadataProcessorSettings> settings, ILogger<MetadataProcessorEngine> logger,
-            MediaFileListenerService mediaFileListenerService, MetadataProcessingService metadataProcessingService, FFmpegMetadataService ffmpegMetadataService)
+            MediaFileListenerService mediaFileListenerService, MetadataProcessingService metadataProcessingService, 
+            FFmpegMetadataService ffmpegMetadataService, MediaTypeDetectorService mediaTypeDetectorService)
         {
             _settings = settings.Value;
             _mediaFileListenerService = mediaFileListenerService;
             _metadataProcessingService = metadataProcessingService;
             _ffmpegMetadataService = ffmpegMetadataService;
+            _mediaTypeDetectorService = mediaTypeDetectorService;
         }
 
         public async Task<Result> Start(IProgress<string> progress)
@@ -48,80 +51,24 @@ namespace Kurmann.Videoschnitt.MetadataProcessor
             // Informiere über die Anzahl der gefundenen Medien-Dateien
             progress.Report($"Anzahl der gefundenen Medien-Dateien: {mediaFiles.Value.Count}");
 
-            // Liste alle Medien-Dateien auf
+            // Iteriere über alle Medien-Dateien und ermittle den Medientyp
             foreach (var mediaFile in mediaFiles.Value)
             {
-                progress.Report(mediaFile.Name);
-            }
-
-            // Gruppiere die gefundenen Medien-Dateien nach Medienset. Ein Medienset ist eine Gruppe von Medien-Dateien, die zusammengehören.
-            var mediaSets = MediasetCollection.Create(mediaFiles.Value,
-                                                      _settings.MediaSetSettings.VideoVersionSuffixes,
-                                                      _settings.MediaSetSettings.ImageVersionSuffixes,
-                                                      _settings.FileTypeSettings.SupportedVideoExtensions,
-                                                      _settings.FileTypeSettings.SupportedImageExtensions);
-
-            // Verarbeite alle Mediensets
-            var result = await Process(mediaSets, progress);
-            if (result.IsFailure)
-            {
-                return Result.Failure($"Fehler bei der Verarbeitung der Mediensets: {result.Error}");
-            }
-
-            return Result.Success();
-        }
-
-        /// <summary>
-        /// Verarbeitet die Metadaten eines Mediensets.
-        /// </summary>
-        private async Task<Result> Process(MediasetCollection mediasetCollection, IProgress<string> progress)
-        {
-            if (mediasetCollection?.Mediasets == null)
-            {
-                return Result.Failure("Keine Mediensets gefunden.");
-            }
-
-            // Iteriere über alle Mediensets
-            foreach (var mediaSet in mediasetCollection.Mediasets)
-            {
-                // Verarbeite das Medienset
-                var result = await Process(mediaSet, progress);
-                if (result.IsFailure)
+                var mediaTypeResult = _mediaTypeDetectorService.DetectMediaType(mediaFile);
+                if (mediaTypeResult.IsFailure)
                 {
-                    return Result.Failure($"Fehler bei der Verarbeitung des Mediensets {mediaSet.Name}: {result.Error}");
+                    progress.Report($"Fehler beim Ermitteln des Medientyps für Datei {mediaFile.Name}: {mediaTypeResult.Error}");
+                    continue;
                 }
-                progress.Report($"Medienset {mediaSet.Name} erfolgreich verarbeitet.");
+
+                // Informiere über den ermittelten Medientyp
+                progress.Report($"Medientyp für Datei {mediaFile.Name}: {mediaTypeResult.Value.GetType().Name}");
+
+
             }
 
             return Result.Success();
         }
-
-        private async Task<Result> Process(MediaSet mediaSet, IProgress<string> progress)
-        {
-            // Nimm die zuerst gefundene QuickTime MOV Datei als Referenz für die Metadaten-Verarbeitung
-            var referenceMediaFile = mediaSet.QuickTimeVideos.FirstOrDefault();
-            if (referenceMediaFile == null)
-            {
-                return Result.Failure($"Keine QuickTime MOV Datei gefunden im Medienset {mediaSet.Name} um die Metadaten auszulesen.");
-            }
-
-            // Informiere über den Beginn der Metadaten-Verarbeitung
-            progress.Report("Beginne mit der Verarbeitung der Metadaten.");
-
-            // Lies die Metadaten der Referenzdatei aus
-            var metadataResult = await _ffmpegMetadataService.GetFFmpegMetadataAsync(referenceMediaFile.FullName);
-            if (metadataResult.IsFailure)
-            {
-                return Result.Failure($"Fehler beim Auslesen der Metadaten der Referenzdatei {referenceMediaFile.Name}: {metadataResult.Error}");
-            }
-
-            // Informiere über die erfolgreiche Verarbeitung der Metadaten
-            progress.Report("Metadaten erfolgreich verarbeitet.");
-
-            // Informiere über die Metadaten der Referenzdatei
-            progress.Report(metadataResult.Value);
-
-            return Result.Success();
-        }
+    
     }
 }

--- a/src/MetadataProcessor/ServiceCollectionExtensions.cs
+++ b/src/MetadataProcessor/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<FFmpegMetadataService>();
         services.AddSingleton<CommandExecutorService>();
         services.AddSingleton<MediaTypeDetectorService>();
+        services.AddSingleton<MediaSetVariantService>();
 
         return services;
     }

--- a/src/MetadataProcessor/ServiceCollectionExtensions.cs
+++ b/src/MetadataProcessor/ServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<MediaFileListenerService>();
         services.AddSingleton<FFmpegMetadataService>();
         services.AddSingleton<CommandExecutorService>();
+        services.AddSingleton<MediaTypeDetectorService>();
 
         return services;
     }

--- a/src/MetadataProcessor/Services/MediaSetVariantService.cs
+++ b/src/MetadataProcessor/Services/MediaSetVariantService.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Logging;
+using Kurmann.Videoschnitt.MetadataProcessor.Entities.SupportedMediaTypes;
+using CSharpFunctionalExtensions;
+using Microsoft.Extensions.Options;
+
+namespace Kurmann.Videoschnitt.MetadataProcessor.Services;
+
+/// <summary>
+/// Verantwortlich für die Verwaltung von Medienset-Varianten.
+public class MediaSetVariantService
+{
+    private readonly MetadataProcessorSettings _settings;
+    private readonly ILogger<MediaSetVariantService> _logger;
+
+    public MediaSetVariantService(IOptions<MetadataProcessorSettings> settings, ILogger<MediaSetVariantService> logger)
+    {
+        _settings = settings.Value;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Gibt die QuickTime-Movie-Variante eines Mpeg4-Videos zurück, die in den gegebenen Medien-Dateien gefunden wurde.
+    /// Die Varianten werden anhand von den Variantensuffixen ermittelt, die in den Einstellungen konfiguriert sind.
+    /// </summary>
+    public Result<QuickTimeMovie> GetQuickTimeMovieVariant(Mpeg4Video mpeg4Video, IEnumerable<FileInfo> mediaFiles)
+    {
+        _logger.LogInformation($"Ermittle QuickTime-Movie-Variante für Mpeg4-Video {mpeg4Video.FileInfo.FullName}");
+
+        var variantSuffixes = _settings.MediaSetSettings?.VideoVersionSuffixes;
+        if (variantSuffixes == null || variantSuffixes.Count == 0)
+        {
+            return Result.Failure<QuickTimeMovie>("Keine Variantensuffixe konfiguriert.");
+        }
+
+        // Suche für das gegebene Mpeg4-Video nach einer passenden QuickTime-Movie-Variante in den gegebenen Medien-Dateien
+        // indem die erste Datei zurückgegeben wird mit identischem Dateinamen, aber mit einem der Variantensuffixe und ohne Dateiendung
+
+        // Nimm als Ausgangslage den Dateinamen des Mpeg4-Videos ohne Variantensuffix und ohne Dateiendung
+        var baseFileName = Path.GetFileNameWithoutExtension(mpeg4Video.FileInfo.Name);
+        foreach (var variantSuffix in variantSuffixes)
+        {
+            // Entferne das Variantensuffix, falls vorhanden
+            var baseFileNameWithoutSuffix = baseFileName.Replace(variantSuffix, string.Empty, StringComparison.InvariantCultureIgnoreCase);
+
+            // Suche nach einer passenden QuickTime-Movie-Variante in den gegebenen Medien-Dateien, die mit dem bereinigten Dateinamen beginnt
+            var quickTimeMovie = mediaFiles
+                .Select(QuickTimeMovie.Create)
+                .Where(result => result.IsSuccess)
+                .Select(result => result.Value)
+                .FirstOrDefault(quickTimeMovie => Path.GetFileNameWithoutExtension(quickTimeMovie.FileInfo.Name).StartsWith(baseFileNameWithoutSuffix, StringComparison.InvariantCultureIgnoreCase));
+
+            // Wenn eine passende QuickTime-Movie-Variante gefunden wurde, gib sie zurück und beende die Suche
+            if (quickTimeMovie != null)
+            {
+                _logger.LogInformation($"QuickTime-Movie-Variante für Mpeg4-Video {mpeg4Video.FileInfo.FullName} gefunden: {quickTimeMovie.FileInfo.FullName}");
+                return Result.Success(quickTimeMovie);
+            }
+        }
+
+        return Result.Failure<QuickTimeMovie>($"Keine QuickTime-Movie-Variante für Mpeg4-Video {mpeg4Video.FileInfo.FullName} gefunden.");
+    }
+}

--- a/src/MetadataProcessor/Services/MediaTypeDetectorService.cs
+++ b/src/MetadataProcessor/Services/MediaTypeDetectorService.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.Logging;
+using CSharpFunctionalExtensions;
+using Kurmann.Videoschnitt.MetadataProcessor.Entities.SupportedMediaTypes;
+
+namespace Kurmann.Videoschnitt.MetadataProcessor.Services;
+
+/// <summary>
+/// Verantwortlich für das Erkennen des Medientyps.
+public class MediaTypeDetectorService
+{
+    private readonly ILogger<MediaTypeDetectorService> _logger;
+
+    public MediaTypeDetectorService(ILogger<MediaTypeDetectorService> logger) => _logger = logger;
+
+    public Result<ISupportedMediaType> DetectMediaType(FileInfo fileInfo)
+    {
+        _logger.LogInformation($"Detecting media type for file {fileInfo.FullName}");
+
+        var mpeg4Video = Mpeg4Video.Create(fileInfo);
+        if (mpeg4Video.IsSuccess)
+        {
+            return mpeg4Video.Value;
+        }
+
+        var quickTimeMovie = QuickTimeMovie.Create(fileInfo);
+        if (quickTimeMovie.IsSuccess)
+        {
+            return quickTimeMovie.Value;
+        }
+
+        var coverArtImage = CoverArtImage.Create(fileInfo);
+        if (coverArtImage.IsSuccess)
+        {
+            return coverArtImage.Value;
+        }
+
+        return Result.Failure<ISupportedMediaType>($"File {fileInfo.FullName} is not a supported media type.");
+    }
+}


### PR DESCRIPTION
Iteriert durch alle Dateien im Eingangsverzeichnis und versucht für jede MPEG-4-Datei die passende QuickTime-Variante zu finden, als Ausgangslage für die Metadatenübertragung.

![image](https://github.com/kurmann/videoschnitt/assets/2642655/2562f783-8839-4a35-8568-1b6d176b982e)
