### PR TITLE
Infuse XML-Metadaten

### DIFF
--- a/src/MetadataProcessor/Entities/FFmpegMetadata.cs
+++ b/src/MetadataProcessor/Entities/FFmpegMetadata.cs
@@ -1,126 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using System.Xml.Linq;
 using CSharpFunctionalExtensions;
 
-namespace Kurmann.Videoschnitt.MetadataProcessor.Entities;
-
-public class FFmpegMetadata
+namespace Kurmann.Videoschnitt.MetadataProcessor.Entities
 {
-    public string? MajorBrand { get; }
-    public string? MinorVersion { get; }
-    public string? CompatibleBrands { get; }
-    public string? Copyright { get; }
-    public DateOnly? Date { get; }
-    public string? Keywords { get; }
-    public string? Title { get; }
-    public string? Album { get; }
-    public string? Artist { get; }
-    public string? Author { get; }
-    public string? DisplayName { get; }
-    public DateOnly? CreationDate { get; }
-    public string? Description { get; }
-    public string? Encoder { get; }
-
-    private FFmpegMetadata(Dictionary<string, string> metadata)
+    public class FFmpegMetadata
     {
-        MajorBrand = metadata.GetValueOrDefault("major_brand");
-        MinorVersion = metadata.GetValueOrDefault("minor_version");
-        CompatibleBrands = metadata.GetValueOrDefault("compatible_brands");
-        Copyright = metadata.GetValueOrDefault("com.apple.quicktime.copyright");
-        Date = ParseDate(metadata.GetValueOrDefault("date"));
-        Keywords = metadata.GetValueOrDefault("keywords");
-        Title = metadata.GetValueOrDefault("title");
-        Album = metadata.GetValueOrDefault("album");
-        Artist = metadata.GetValueOrDefault("artist");
-        Author = metadata.GetValueOrDefault("com.apple.quicktime.author");
-        DisplayName = metadata.GetValueOrDefault("com.apple.quicktime.displayname");
-        CreationDate = ParseDate(metadata.GetValueOrDefault("com.apple.quicktime.creationdate"));
-        Description = metadata.GetValueOrDefault("com.apple.quicktime.description");
-        Encoder = metadata.GetValueOrDefault("encoder");
-    }
+        public string? MajorBrand { get; }
+        public string? MinorVersion { get; }
+        public string? CompatibleBrands { get; }
+        public string? Copyright { get; }
+        public DateOnly? Date { get; }
+        public string? Keywords { get; }
+        public string? Title { get; private set; }
+        public string? Album { get; }
+        public string? Artist { get; }
+        public string? Author { get; }
+        public string? DisplayName { get; }
+        public DateOnly? CreationDate { get; }
+        public string? Description { get; }
+        public string? Encoder { get; }
+        public DateOnly? PublishedDate { get; private set; }
 
-    public static Result<FFmpegMetadata> Create(string rawString)
-    {
-        // Prüfen, ob die Zeichenfolge leer ist
-        if (string.IsNullOrWhiteSpace(rawString))
+        private FFmpegMetadata(Dictionary<string, string> metadata)
         {
-            return Result.Failure<FFmpegMetadata>("The FFMpeg raw string is empty.");
+            MajorBrand = metadata.GetValueOrDefault("major_brand");
+            MinorVersion = metadata.GetValueOrDefault("minor_version");
+            CompatibleBrands = metadata.GetValueOrDefault("compatible_brands");
+            Copyright = metadata.GetValueOrDefault("com.apple.quicktime.copyright");
+            Date = ParseDate(metadata.GetValueOrDefault("date"));
+            Keywords = metadata.GetValueOrDefault("keywords");
+            Title = metadata.GetValueOrDefault("title");
+            Album = metadata.GetValueOrDefault("album");
+            Artist = metadata.GetValueOrDefault("artist");
+            Author = metadata.GetValueOrDefault("com.apple.quicktime.author");
+            DisplayName = metadata.GetValueOrDefault("com.apple.quicktime.displayname");
+            CreationDate = ParseDate(metadata.GetValueOrDefault("com.apple.quicktime.creationdate"));
+            Description = metadata.GetValueOrDefault("com.apple.quicktime.description");
+            Encoder = metadata.GetValueOrDefault("encoder");
+
+            ParseTitleForDate();
         }
 
-        var metadata = new Dictionary<string, string>();
-
-        try
+        public static Result<FFmpegMetadata> Create(string rawString)
         {
-            foreach (var line in rawString.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
+            if (string.IsNullOrWhiteSpace(rawString))
             {
-                if (line.StartsWith(";") || string.IsNullOrWhiteSpace(line)) continue;
+                return Result.Failure<FFmpegMetadata>("The FFMpeg raw string is empty.");
+            }
 
-                var parts = line.Split('=', 2);
-                if (parts.Length == 2)
+            var metadata = new Dictionary<string, string>();
+
+            try
+            {
+                foreach (var line in rawString.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
                 {
-                    metadata[parts[0].Trim()] = parts[1].Trim();
+                    if (line.StartsWith(";") || string.IsNullOrWhiteSpace(line)) continue;
+
+                    var parts = line.Split('=', 2);
+                    if (parts.Length == 2)
+                    {
+                        metadata[parts[0].Trim()] = parts[1].Trim();
+                    }
                 }
             }
+            catch (Exception ex)
+            {
+                return Result.Failure<FFmpegMetadata>($"Error while parsing FFmpeg metadata: {ex.Message}");
+            }
+
+            return new FFmpegMetadata(metadata);
         }
-        catch (Exception ex)
+
+        private static DateOnly? ParseDate(string? dateString)
         {
-            return Result.Failure<FFmpegMetadata>($"Error while parsing FFmpeg metadata: {ex.Message}");
+            if (DateOnly.TryParse(dateString, out var date))
+            {
+                return date;
+            }
+
+            return null;
         }
 
-        return new FFmpegMetadata(metadata);
-    }
-
-    private static DateOnly? ParseDate(string? dateString)
-    {
-        if (DateOnly.TryParse(dateString, out var date))
+        private void ParseTitleForDate()
         {
-            return date;
+            if (string.IsNullOrEmpty(Title))
+                return;
+
+            var parts = Title.Split(' ', 2);
+            if (parts.Length == 2 && DateOnly.TryParseExact(parts[0], "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedDate))
+            {
+                PublishedDate = parsedDate;
+                Title = parts[1];
+            }
         }
 
-        return null;
-    }
-
-    public XDocument ToInfuseXml()
-    {
-        var mediaElement = new XElement("media", new XAttribute("type", "Other"));
-
-        if (!string.IsNullOrEmpty(Title))
-            mediaElement.Add(new XElement("title", Title));
-        
-        if (!string.IsNullOrEmpty(Description))
-            mediaElement.Add(new XElement("description", Description));
-        
-        if (!string.IsNullOrEmpty(Artist))
-            mediaElement.Add(new XElement("artist", Artist));
-        
-        if (!string.IsNullOrEmpty(Copyright))
-            mediaElement.Add(new XElement("copyright", Copyright));
-        
-        if (Date.HasValue)
-            mediaElement.Add(new XElement("published", Date.Value.ToString("yyyy-MM-dd")));
-        
-        if (CreationDate.HasValue)
-            mediaElement.Add(new XElement("releasedate", CreationDate.Value.ToString("yyyy-MM-dd")));
-        
-        if (!string.IsNullOrEmpty(Author))
-            mediaElement.Add(new XElement("studio", Author));
-        
-        if (!string.IsNullOrEmpty(Keywords))
-            mediaElement.Add(new XElement("keywords", Keywords));
-        
-        if (!string.IsNullOrEmpty(Artist))
+        public XDocument ToInfuseXml()
         {
-            var producersElement = new XElement("producers");
-            producersElement.Add(new XElement("name", Artist));
-            mediaElement.Add(producersElement);
-        }
-        
-        if (!string.IsNullOrEmpty(Artist))
-        {
-            var directorsElement = new XElement("directors");
-            directorsElement.Add(new XElement("name", Artist));
-            mediaElement.Add(directorsElement);
-        }
+            var mediaElement = new XElement("media", new XAttribute("type", "Other"));
 
-        return new XDocument(new XDeclaration("1.0", "UTF-8", "yes"), mediaElement);
+            if (!string.IsNullOrEmpty(Title))
+                mediaElement.Add(new XElement("title", Title));
+            
+            if (!string.IsNullOrEmpty(Description))
+                mediaElement.Add(new XElement("description", Description));
+            
+            if (!string.IsNullOrEmpty(Artist))
+                mediaElement.Add(new XElement("artist", Artist));
+            
+            if (!string.IsNullOrEmpty(Copyright))
+                mediaElement.Add(new XElement("copyright", Copyright));
+            
+            if (PublishedDate.HasValue)
+                mediaElement.Add(new XElement("published", PublishedDate.Value.ToString("yyyy-MM-dd")));
+            else if (Date.HasValue)
+                mediaElement.Add(new XElement("published", Date.Value.ToString("yyyy-MM-dd")));
+
+            if (CreationDate.HasValue)
+                mediaElement.Add(new XElement("releasedate", CreationDate.Value.ToString("yyyy-MM-dd")));
+            
+            if (!string.IsNullOrEmpty(Author))
+                mediaElement.Add(new XElement("studio", Author));
+            
+            if (!string.IsNullOrEmpty(Keywords))
+                mediaElement.Add(new XElement("keywords", Keywords));
+            
+            if (!string.IsNullOrEmpty(Artist))
+            {
+                var producersElement = new XElement("producers");
+                producersElement.Add(new XElement("name", Artist));
+                mediaElement.Add(producersElement);
+            }
+            
+            if (!string.IsNullOrEmpty(Artist))
+            {
+                var directorsElement = new XElement("directors");
+                directorsElement.Add(new XElement("name", Artist));
+                mediaElement.Add(directorsElement);
+            }
+
+            return new XDocument(new XDeclaration("1.0", "UTF-8", "yes"), mediaElement);
+        }
     }
 }

--- a/src/MetadataProcessor/Entities/FFmpegMetadata.cs
+++ b/src/MetadataProcessor/Entities/FFmpegMetadata.cs
@@ -25,7 +25,9 @@ namespace Kurmann.Videoschnitt.MetadataProcessor.Entities
         public string? Encoder { get; }
         public DateOnly? PublishedDate { get; private set; }
 
-        private FFmpegMetadata(Dictionary<string, string> metadata)
+        public string RawString { get; }
+
+        private FFmpegMetadata(Dictionary<string, string> metadata, string rawString)
         {
             MajorBrand = metadata.GetValueOrDefault("major_brand");
             MinorVersion = metadata.GetValueOrDefault("minor_version");
@@ -43,6 +45,8 @@ namespace Kurmann.Videoschnitt.MetadataProcessor.Entities
             Encoder = metadata.GetValueOrDefault("encoder");
 
             ParseTitleForDate();
+
+            RawString = rawString;
         }
 
         public static Result<FFmpegMetadata> Create(string rawString)
@@ -72,7 +76,7 @@ namespace Kurmann.Videoschnitt.MetadataProcessor.Entities
                 return Result.Failure<FFmpegMetadata>($"Error while parsing FFmpeg metadata: {ex.Message}");
             }
 
-            return new FFmpegMetadata(metadata);
+            return new FFmpegMetadata(metadata, rawString);
         }
 
         private static DateOnly? ParseDate(string? dateString)

--- a/src/MetadataProcessor/Entities/FFmpegMetadata.cs
+++ b/src/MetadataProcessor/Entities/FFmpegMetadata.cs
@@ -1,3 +1,4 @@
+using System.Xml.Linq;
 using CSharpFunctionalExtensions;
 
 namespace Kurmann.Videoschnitt.MetadataProcessor.Entities;
@@ -60,7 +61,7 @@ public class FFmpegMetadata
                 }
             }
         }
-        catch (System.Exception ex)
+        catch (Exception ex)
         {
             return Result.Failure<FFmpegMetadata>($"Error while parsing FFmpeg metadata: {ex.Message}");
         }
@@ -76,5 +77,50 @@ public class FFmpegMetadata
         }
 
         return null;
+    }
+
+    public XDocument ToInfuseXml()
+    {
+        var mediaElement = new XElement("media", new XAttribute("type", "Other"));
+
+        if (!string.IsNullOrEmpty(Title))
+            mediaElement.Add(new XElement("title", Title));
+        
+        if (!string.IsNullOrEmpty(Description))
+            mediaElement.Add(new XElement("description", Description));
+        
+        if (!string.IsNullOrEmpty(Artist))
+            mediaElement.Add(new XElement("artist", Artist));
+        
+        if (!string.IsNullOrEmpty(Copyright))
+            mediaElement.Add(new XElement("copyright", Copyright));
+        
+        if (Date.HasValue)
+            mediaElement.Add(new XElement("published", Date.Value.ToString("yyyy-MM-dd")));
+        
+        if (CreationDate.HasValue)
+            mediaElement.Add(new XElement("releasedate", CreationDate.Value.ToString("yyyy-MM-dd")));
+        
+        if (!string.IsNullOrEmpty(Author))
+            mediaElement.Add(new XElement("studio", Author));
+        
+        if (!string.IsNullOrEmpty(Keywords))
+            mediaElement.Add(new XElement("keywords", Keywords));
+        
+        if (!string.IsNullOrEmpty(Artist))
+        {
+            var producersElement = new XElement("producers");
+            producersElement.Add(new XElement("name", Artist));
+            mediaElement.Add(producersElement);
+        }
+        
+        if (!string.IsNullOrEmpty(Artist))
+        {
+            var directorsElement = new XElement("directors");
+            directorsElement.Add(new XElement("name", Artist));
+            mediaElement.Add(directorsElement);
+        }
+
+        return new XDocument(new XDeclaration("1.0", "UTF-8", "yes"), mediaElement);
     }
 }

--- a/src/MetadataProcessor/MetadataProcessorEngine.cs
+++ b/src/MetadataProcessor/MetadataProcessorEngine.cs
@@ -70,81 +70,98 @@ namespace Kurmann.Videoschnitt.MetadataProcessor
                 // Informiere über den ermittelten Medientyp
                 progress.Report($"Medientyp für Datei {mediaFile.Name}: {mediaTypeResult.Value.GetType().Name}");
 
-                // Wenn die Datei ein Mpeg4-Video ist, ermittle die QuickTime-Movie-Variante
-                var infuseXml = Maybe<XDocument>.None;
-                if (mediaTypeResult.Value is Mpeg4Video mpeg4Video)
+                // Wenn die Datei ein QuickTime-Movie ist, extrahiere die Metadaten und erstelle ein Infuse-XML-Objekt
+                if (mediaTypeResult.Value is QuickTimeMovie quickTimeMovie)
                 {
-                    var quickTimeMovieVariantResult = _mediaSetVariantService.GetQuickTimeMovieVariant(mpeg4Video, mediaFiles.Value);
-                    if (quickTimeMovieVariantResult.IsFailure)
-                    {
-                        progress.Report($"Fehler beim Ermitteln der QuickTime-Movie-Variante für Mpeg4-Video {mpeg4Video.FileInfo.Name}: {quickTimeMovieVariantResult.Error}");
-                        progress.Report($"Extrahiere Metadaten aus Mpeg4-Video {mpeg4Video.FileInfo.Name}");
-
-                        var readMpeg4MetadataResult = await _infuseXmlService.ReadMetadataFromMpeg4Video(mpeg4Video, progress);
-                        if (readMpeg4MetadataResult.IsFailure)
-                        {
-                            progress.Report(readMpeg4MetadataResult.Error);
-                        }
-
-                        // Informiere über die extrahierten Metadaten im Infuse-XML-Format
-                        progress.Report($"Infuse-XML aus Metadaten von Mpeg4-Video {mpeg4Video.FileInfo.Name}: {readMpeg4MetadataResult.Value}");
-
-                        // Speichere das Infuse-XML-Objekt
-                        infuseXml = readMpeg4MetadataResult.Value;
-
-                        // Fahre mit der nächsten Datei fort
-                        continue;
-                    }
-
-                    // Prüfe ob eine QuickTime-Movie-Variante gefunden wurde
-                    if (quickTimeMovieVariantResult.Value.HasNoValue)
-                    {
-                        var readMpeg4MetadataResult = await _infuseXmlService.ReadMetadataFromMpeg4Video(mpeg4Video, progress);
-                        if (readMpeg4MetadataResult.IsFailure)
-                        {
-                            progress.Report(readMpeg4MetadataResult.Error);
-                        }
-
-                        // Informiere über die extrahierten Metadaten im Infuse-XML-Format
-                        progress.Report($"Infuse-XML aus Metadaten von Mpeg4-Video {mpeg4Video.FileInfo.Name}: {readMpeg4MetadataResult.Value}");
-
-                        // Speichere das Infuse-XML-Objekt
-                        infuseXml = readMpeg4MetadataResult.Value;
-
-                        // Fahre mit der nächsten Datei fort
-                        continue;
-                    }
-
-                    // Informiere über die gefundene QuickTime-Movie-Variante
-                    progress.Report($"QuickTime-Movie-Variante für Mpeg4-Video {mpeg4Video.FileInfo.Name}: {quickTimeMovieVariantResult.Value.Value.FileInfo.Name}");
-
-                    // Extrahiere Metadaten aus der QuickTime-Movie-Variante
-                    var readQuickTimeMetadataResult = await _infuseXmlService.ReadMetdataFromQuickTimeMovie(quickTimeMovieVariantResult.Value.Value, progress);
+                    var readQuickTimeMetadataResult = await _infuseXmlService.ReadMetdataFromQuickTimeMovie(quickTimeMovie, progress);
                     if (readQuickTimeMetadataResult.IsFailure)
                     {
                         progress.Report(readQuickTimeMetadataResult.Error);
                     }
 
                     // Informiere über die extrahierten Metadaten im Infuse-XML-Format
-                    progress.Report($"Infuse-XML aus Metadaten von QuickTime-Movie {quickTimeMovieVariantResult.Value.Value.FileInfo.Name}: {readQuickTimeMetadataResult.Value}");
+                    progress.Report($"Infuse-XML aus Metadaten von QuickTime-Movie {quickTimeMovie.FileInfo.Name}: {readQuickTimeMetadataResult.Value}");
 
                     // Speichere das Infuse-XML-Objekt
-                    infuseXml = readQuickTimeMetadataResult.Value;
+                    var infuseXml = readQuickTimeMetadataResult.Value;
+
+                    // Erstelle den Dateinamen für das Infuse-XML-Objekt
+                    var infuseXmlFileName = _mediaSetVariantService.GetInfuseXmlFileName(quickTimeMovie.FileInfo);
+                    if (infuseXmlFileName.IsFailure)
+                    {
+                        progress.Report(infuseXmlFileName.Error);
+                        
+                        // Fahre mit der nächsten Datei fort
+                        continue;
+                    }
+
+                    // Informiere über den Dateinamen des Infuse-XML-Objekts
+                    progress.Report($"Dateiname des Infuse-XML-Objekts für Medien-Objekt {mediaFile.FullName}: {infuseXmlFileName.Value.FullName}");
+
+                    // Schreibe die Datei
+                    infuseXml.Save(infuseXmlFileName.Value.FullName);
+
+                    // Informiere über den Erfolg
+                    progress.Report($"Infuse-XML-Datei für Medien-Objekt {mediaFile.FullName} erfolgreich geschrieben.");
 
                     // Fahre mit der nächsten Datei fort
                     continue;
                 }
 
-                // Ermittle den Dateinamen des Infuse-XML-Objekts. Der Dateiname entspricht dem Dateinamen des Medien-Objekts ohne Varianten-Suffix und mit der Dateiendung '.xml'
-                var infuseXmlFileName = _mediaSetVariantService.GetInfuseXmlFileName(mediaFile);
-                if (infuseXmlFileName.IsFailure)
-                {
-                    progress.Report(infuseXmlFileName.Error);
-                    continue;
-                }
 
-                // Informiere über den Dateinamen des Infuse-XML-Objekts
-                progress.Report($"Dateiname des Infuse-XML-Objekts für Medien-Objekt {mediaFile.FullName}: {infuseXmlFileName.Value.FullName}");
+                // Wenn die Datei ein Mpeg4-Video ist, dann schreibe die Infuse-XML-Datei nur wenn kein Infuse-XML-Objekt bereits besteht, 
+                // da die QuickTime-Movie-Variante bevorzugt wird aufgrund der besseren Metadaten
+                if (mediaTypeResult.Value is Mpeg4Video mpeg4Video)
+                {
+                    // Informiere über das Mpeg4-Video und was wir nun vorhaben
+                    progress.Report("Mpeg4-Video gefunden. Es wird geprüft, ob bereits ein Infuse-XML-Objekt existiert.");
+
+                    // Ermittle den Dateinamen des Infuse-XML-Objekts, nachdem wir suchen, ob bereits ein Infuse-XML-Objekt existiert
+                    var infuseXmlFileName = _mediaSetVariantService.GetInfuseXmlFileName(mpeg4Video.FileInfo);
+                    if (infuseXmlFileName.IsFailure)
+                    {
+                        progress.Report(infuseXmlFileName.Error);
+
+                        // Fahre mit der nächsten Datei fort
+                        continue;
+                    }
+
+                    // Informiere über den Dateinamen des Infuse-XML-Objekts
+                    progress.Report($"Dateiname des Infuse-XML-Objekts für Medien-Objekt {mediaFile.FullName}: {infuseXmlFileName.Value.FullName}");
+
+                    // Prüfe ob bereits ein Infuse-XML-Objekt existiert
+                    if (infuseXmlFileName.Value.Exists)
+                    {
+                        progress.Report($"Infuse-XML-Datei für Medien-Objekt {mediaFile.FullName} existiert bereits. Es wird keine neue Datei geschrieben.");
+
+                        // Fahre mit der nächsten Datei fort
+                        continue;
+                    }
+
+                    // Informiere über das Fehlen des Infuse-XML-Objekts und was wir nun vorhaben
+                    progress.Report($"Infuse-XML-Datei für Medien-Objekt {mediaFile.FullName} existiert nicht. Es wird eine neue Datei geschrieben.");
+
+                    // Extrahiere die Metadaten und erstelle ein Infuse-XML-Objekt
+                    progress.Report($"Extrahiere Metadaten aus Mpeg4-Video {mpeg4Video.FileInfo.Name}");
+                    var readMpeg4MetadataResult = await _infuseXmlService.ReadMetadataFromMpeg4Video(mpeg4Video, progress);
+                    if (readMpeg4MetadataResult.IsFailure)
+                    {
+                        progress.Report(readMpeg4MetadataResult.Error);
+                        continue;
+                    }
+
+                    // Informiere über die extrahierten Metadaten im Infuse-XML-Format
+                    progress.Report($"Infuse-XML aus Metadaten von Mpeg4-Video {mpeg4Video.FileInfo.Name}: {readMpeg4MetadataResult.Value}");
+
+                    // Speichere das Infuse-XML-Objekt
+                    var infuseXml = readMpeg4MetadataResult.Value;
+
+                    // Schreibe die Datei
+                    infuseXml.Save(infuseXmlFileName.Value.FullName);
+
+                    // Informiere über den Erfolg
+                    progress.Report($"Infuse-XML-Datei für Medien-Objekt {mediaFile.FullName} erfolgreich geschrieben.");
+                }
             }
 
             return Result.Success();

--- a/src/MetadataProcessor/MetadataProcessorEngine.cs
+++ b/src/MetadataProcessor/MetadataProcessorEngine.cs
@@ -71,7 +71,7 @@ namespace Kurmann.Videoschnitt.MetadataProcessor
                 progress.Report($"Medientyp für Datei {mediaFile.Name}: {mediaTypeResult.Value.GetType().Name}");
 
                 // Wenn die Datei ein Mpeg4-Video ist, ermittle die QuickTime-Movie-Variante
-                XDocument infuseXml = null;
+                var infuseXml = Maybe<XDocument>.None;
                 if (mediaTypeResult.Value is Mpeg4Video mpeg4Video)
                 {
                     var quickTimeMovieVariantResult = _mediaSetVariantService.GetQuickTimeMovieVariant(mpeg4Video, mediaFiles.Value);
@@ -134,6 +134,17 @@ namespace Kurmann.Videoschnitt.MetadataProcessor
                     // Fahre mit der nächsten Datei fort
                     continue;
                 }
+
+                // Ermittle den Dateinamen des Infuse-XML-Objekts. Der Dateiname entspricht dem Dateinamen des Medien-Objekts ohne Varianten-Suffix und mit der Dateiendung '.xml'
+                var infuseXmlFileName = _mediaSetVariantService.GetInfuseXmlFileName(mediaFile);
+                if (infuseXmlFileName.IsFailure)
+                {
+                    progress.Report(infuseXmlFileName.Error);
+                    continue;
+                }
+
+                // Informiere über den Dateinamen des Infuse-XML-Objekts
+                progress.Report($"Dateiname des Infuse-XML-Objekts für Medien-Objekt {mediaFile.FullName}: {infuseXmlFileName.Value.FullName}");
             }
 
             return Result.Success();

--- a/src/MetadataProcessor/MetadataProcessorEngine.cs
+++ b/src/MetadataProcessor/MetadataProcessorEngine.cs
@@ -79,8 +79,8 @@ namespace Kurmann.Videoschnitt.MetadataProcessor
                         progress.Report(readQuickTimeMetadataResult.Error);
                     }
 
-                    // Informiere über die extrahierten Metadaten im Infuse-XML-Format
-                    progress.Report($"Infuse-XML aus Metadaten von QuickTime-Movie {quickTimeMovie.FileInfo.Name}: {readQuickTimeMetadataResult.Value}");
+                    // Informiere über die extrahierten Metadaten im Infuse-XML-Format mit Zeilenumbruch vor dem XML-Tag
+                    progress.Report($"Infuse-XML aus Metadaten von QuickTime-Movie {quickTimeMovie.FileInfo.Name}:\n{readQuickTimeMetadataResult.Value}");
 
                     // Speichere das Infuse-XML-Objekt
                     var infuseXml = readQuickTimeMetadataResult.Value;
@@ -96,7 +96,7 @@ namespace Kurmann.Videoschnitt.MetadataProcessor
                     }
 
                     // Informiere über den Dateinamen des Infuse-XML-Objekts
-                    progress.Report($"Dateiname des Infuse-XML-Objekts für Medien-Objekt {mediaFile.FullName}: {infuseXmlFileName.Value.FullName}");
+                    progress.Report($"Dateiname des Infuse-XML-Objekts für Medien-Objekt \n{mediaFile.FullName}:\n{infuseXmlFileName.Value.FullName}");
 
                     // Schreibe die Datei
                     infuseXml.Save(infuseXmlFileName.Value.FullName);
@@ -127,7 +127,7 @@ namespace Kurmann.Videoschnitt.MetadataProcessor
                     }
 
                     // Informiere über den Dateinamen des Infuse-XML-Objekts
-                    progress.Report($"Dateiname des Infuse-XML-Objekts für Medien-Objekt {mediaFile.FullName}: {infuseXmlFileName.Value.FullName}");
+                    progress.Report($"Dateiname des Infuse-XML-Objekts für Medien-Objekt \n{mediaFile.FullName}:\n{infuseXmlFileName.Value.FullName}");
 
                     // Prüfe ob bereits ein Infuse-XML-Objekt existiert
                     if (infuseXmlFileName.Value.Exists)
@@ -150,8 +150,8 @@ namespace Kurmann.Videoschnitt.MetadataProcessor
                         continue;
                     }
 
-                    // Informiere über die extrahierten Metadaten im Infuse-XML-Format
-                    progress.Report($"Infuse-XML aus Metadaten von Mpeg4-Video {mpeg4Video.FileInfo.Name}: {readMpeg4MetadataResult.Value}");
+                    // Informiere über die extrahierten Metadaten im Infuse-XML-Format mit Zeilenumbruch vor dem XML-Tag
+                    progress.Report($"Infuse-XML aus Metadaten von Mpeg4-Video {mpeg4Video.FileInfo.Name}:\n{readMpeg4MetadataResult.Value}");
 
                     // Speichere das Infuse-XML-Objekt
                     var infuseXml = readMpeg4MetadataResult.Value;

--- a/src/MetadataProcessor/ServiceCollectionExtensions.cs
+++ b/src/MetadataProcessor/ServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<CommandExecutorService>();
         services.AddSingleton<MediaTypeDetectorService>();
         services.AddSingleton<MediaSetVariantService>();
+        services.AddSingleton<InfuseXmlService>();
 
         return services;
     }

--- a/src/MetadataProcessor/Services/InfuseXmlService.cs
+++ b/src/MetadataProcessor/Services/InfuseXmlService.cs
@@ -37,7 +37,7 @@ namespace Kurmann.Videoschnitt.MetadataProcessor.Services
             }
 
             // Informiere über die extrahierten Metadaten
-            progress.Report($"Extrahierte Metadaten aus QuickTime-Movie {quickTimeMovie.FileInfo.Name}: {ffmpegMetadata.Value}");
+            progress.Report($"Extrahierte Metadaten aus QuickTime-Movie {quickTimeMovie.FileInfo.Name}:\n{ffmpegMetadata.Value.RawString}");
 
             // Erstelle ein Infuse-XML-Objekt aus den Metadaten
             var infuseXml = ffmpegMetadata.Value.ToInfuseXml();

--- a/src/MetadataProcessor/Services/InfuseXmlService.cs
+++ b/src/MetadataProcessor/Services/InfuseXmlService.cs
@@ -1,0 +1,73 @@
+using Microsoft.Extensions.Logging;
+using CSharpFunctionalExtensions;
+using System.Xml.Linq;
+using Kurmann.Videoschnitt.MetadataProcessor.Entities;
+using Kurmann.Videoschnitt.MetadataProcessor.Entities.SupportedMediaTypes;
+
+namespace Kurmann.Videoschnitt.MetadataProcessor.Services
+{
+    /// <summary>
+    /// Verantwortlich für das Erstellen von Infuse-XML-Dateien.
+    /// </summary>
+    public class InfuseXmlService
+    {
+        private readonly ILogger<InfuseXmlService> _logger;
+        private readonly FFmpegMetadataService _ffmpegMetadataService;
+
+        public InfuseXmlService(ILogger<InfuseXmlService> logger, FFmpegMetadataService ffmpegMetadataService)
+        {
+            _logger = logger;
+            _ffmpegMetadataService = ffmpegMetadataService;
+        }
+
+        public async Task<Result<XDocument>> ReadMetdataFromQuickTimeMovie(QuickTimeMovie quickTimeMovie, IProgress<string> progress)
+        {
+            progress.Report($"Extrahiere Metadaten aus QuickTime-Movie {quickTimeMovie.FileInfo.Name}");
+            var metadataResult = await _ffmpegMetadataService.GetFFmpegMetadataAsync(quickTimeMovie.FileInfo.FullName);
+            if (metadataResult.IsFailure)
+            {
+                return Result.Failure<XDocument>(($"Fehler beim Extrahieren der Metadaten aus QuickTime-Movie {quickTimeMovie.FileInfo.Name}: {metadataResult.Error}"));
+            }
+
+            // Parse die FFMpeg-Metadaten
+            var ffmpegMetadata = FFmpegMetadata.Create(metadataResult.Value);
+            if (ffmpegMetadata.IsFailure)
+            {
+                return Result.Failure<XDocument>($"Fehler beim Parsen der extrahierten Metadaten aus QuickTime-Movie {quickTimeMovie.FileInfo.Name}: {ffmpegMetadata.Error}");
+            }
+
+            // Informiere über die extrahierten Metadaten
+            progress.Report($"Extrahierte Metadaten aus QuickTime-Movie {quickTimeMovie.FileInfo.Name}: {ffmpegMetadata.Value}");
+
+            // Erstelle ein Infuse-XML-Objekt aus den Metadaten
+            var infuseXml = ffmpegMetadata.Value.ToInfuseXml();
+            return infuseXml;
+        }
+
+        public async Task<Result<XDocument>> ReadMetadataFromMpeg4Video(Mpeg4Video mpeg4Video, IProgress<string> progress)
+        {
+            progress.Report($"Extrahiere Metadaten aus Mpeg4-Video {mpeg4Video.FileInfo.Name}");
+            var metadataResult = await _ffmpegMetadataService.GetFFmpegMetadataAsync(mpeg4Video.FileInfo.FullName);
+            if (metadataResult.IsFailure)
+            {
+                return Result.Failure<XDocument>($"Fehler beim Extrahieren der Metadaten aus Mpeg4-Video {mpeg4Video.FileInfo.Name}: {metadataResult.Error}");
+            }
+
+            // Parse die FFMpeg-Metadaten
+            var ffmpegMetadata = FFmpegMetadata.Create(metadataResult.Value);
+            if (ffmpegMetadata.IsFailure)
+            {
+                return Result.Failure<XDocument>($"Fehler beim Parsen der extrahierten Metadaten aus Mpeg4-Video {mpeg4Video.FileInfo.Name}: {ffmpegMetadata.Error}");
+            }
+
+            // Informiere über die extrahierten Metadaten
+            progress.Report($"Extrahierte Metadaten aus Mpeg4-Video {mpeg4Video.FileInfo.Name}: {ffmpegMetadata.Value}");
+
+            // Erstelle ein Infuse-XML-Objekt aus den Metadaten
+            var infuseXml = ffmpegMetadata.Value.ToInfuseXml();
+            progress.Report($"Infuse-XML aus Metadaten von Mpeg4-Video {mpeg4Video.FileInfo.Name}: {infuseXml}");
+
+            return infuseXml;
+        }
+    }
+}

--- a/src/MetadataProcessor/Services/MediaSetVariantService.cs
+++ b/src/MetadataProcessor/Services/MediaSetVariantService.cs
@@ -22,14 +22,14 @@ public class MediaSetVariantService
     /// Gibt die QuickTime-Movie-Variante eines Mpeg4-Videos zurück, die in den gegebenen Medien-Dateien gefunden wurde.
     /// Die Varianten werden anhand von den Variantensuffixen ermittelt, die in den Einstellungen konfiguriert sind.
     /// </summary>
-    public Result<QuickTimeMovie> GetQuickTimeMovieVariant(Mpeg4Video mpeg4Video, IEnumerable<FileInfo> mediaFiles)
+    public Result<Maybe<QuickTimeMovie>> GetQuickTimeMovieVariant(Mpeg4Video mpeg4Video, IEnumerable<FileInfo> mediaFiles)
     {
         _logger.LogInformation($"Ermittle QuickTime-Movie-Variante für Mpeg4-Video {mpeg4Video.FileInfo.FullName}");
 
         var variantSuffixes = _settings.MediaSetSettings?.VideoVersionSuffixes;
         if (variantSuffixes == null || variantSuffixes.Count == 0)
         {
-            return Result.Failure<QuickTimeMovie>("Keine Variantensuffixe konfiguriert.");
+            return Result.Failure<Maybe<QuickTimeMovie>>("Keine Variantensuffixe für QuickTime-Movie-Varianten konfiguriert.");
         }
 
         // Suche für das gegebene Mpeg4-Video nach einer passenden QuickTime-Movie-Variante in den gegebenen Medien-Dateien
@@ -53,10 +53,11 @@ public class MediaSetVariantService
             if (quickTimeMovie != null)
             {
                 _logger.LogInformation($"QuickTime-Movie-Variante für Mpeg4-Video {mpeg4Video.FileInfo.FullName} gefunden: {quickTimeMovie.FileInfo.FullName}");
-                return Result.Success(quickTimeMovie);
+                return Result.Success<Maybe<QuickTimeMovie>>(quickTimeMovie);
             }
         }
 
-        return Result.Failure<QuickTimeMovie>($"Keine QuickTime-Movie-Variante für Mpeg4-Video {mpeg4Video.FileInfo.FullName} gefunden.");
+        // Wenn keine passende QuickTime-Movie-Variante gefunden wurde, gib None zurück. Dies ist kein Fehler.
+        return Result.Success<Maybe<QuickTimeMovie>>(Maybe<QuickTimeMovie>.None);
     }
 }

--- a/testdata/2024-06-05 Zeitraffer Wolken Testaufnahme.xml
+++ b/testdata/2024-06-05 Zeitraffer Wolken Testaufnahme.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<media type="Other">
+  <title>Zeitraffer Wolken Testaufnahme</title>
+  <description>Wolkenschauspiel als Testaufnahme. Aufgenommen in AppleLog. Color Grading.</description>
+  <artist>Patrick Kurmann</artist>
+  <copyright>© Patrick Kurmann 2024</copyright>
+  <published>2024-06-05</published>
+  <releasedate>2024-06-09</releasedate>
+  <studio>Patrick Kurmann</studio>
+  <keywords>5.06.24</keywords>
+  <producers>
+    <name>Patrick Kurmann</name>
+  </producers>
+  <directors>
+    <name>Patrick Kurmann</name>
+  </directors>
+</media>


### PR DESCRIPTION
Es wird nun aus den Videodateien eine Infuse XML-Datei geschrieben die vom Medienplayer Infuse direkt [interpretiert](https://support.firecore.com/hc/en-us/articles/4405042929559-Overriding-Artwork-and-Metadata) wird. Gleichzeitig dient die XML-Datei der Applikation als Zwischenspeicher für die Metadaten für die weitere Verarbeitung.

![image](https://github.com/kurmann/videoschnitt/assets/2642655/86bb9a8c-c384-44bd-951e-1ecc7e8e34b4)
