### PR TITLE
Variantensuffixe aktualisiert

### DIFF
--- a/src/MetadataProcessor/MetadataProcessorSettings.cs
+++ b/src/MetadataProcessor/MetadataProcessorSettings.cs
@@ -16,7 +16,7 @@ public class MediaSetSettings
     /// <summary>
     /// Liste der Varianten-Suffixe, die in den Dateinamen von Videos vorkommen können, einschließlich des Trennzeichens.
     /// </summary>
-    public List<string>? VideoVersionSuffixes { get; set; } = new List<string>{"-4K-Internet", "-4K-Medienserver", "-1080p-Internet"};
+    public List<string>? VideoVersionSuffixes { get; set; } = new List<string>{"-4K-Internet", "-4K60-Medienserver", "-4K30-Medienserver", "-1080p-Internet"};
 
     /// <summary>
     /// Liste der Varianten-Suffixe, die in den Dateinamen von Bilddateien vorkommen können, einschließlich des Trennzeichens.


### PR DESCRIPTION
`-4K60-Medienserver` und `-4K30-Medienserver` wurden beide als Variantensuffixe von Videos hinzugefügt. Dies ist relevant bei der Ermittlung des Basisnamens und dem Schreiben der Infuse XML-Datei.