### PR TITLE
Datei für Umgebungsvariablen

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "8080:8080"
     env_file:
-      - .env
+      - docker-environment.txt
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
       - PORT=8080

--- a/docker-environment.txt
+++ b/docker-environment.txt
@@ -1,0 +1,1 @@
+MetadataProcessing__InputDirectory="/Users/patrickkurmann/Movies/Final Cut Exporte"


### PR DESCRIPTION
`docker-compose.yml` benutzt nun statt `.env` die neue `docker-environment.txt`-Datei. Diese nicht-versteckte Datei erleichtert die Bearbeitung von Verzeichnissen, insbesondere wenn aus Windows-Betriebssystemen aus editiert wird.