### PR TITLE
Verschieben von Medien in die Infuse-Mediathek

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,9 +8,6 @@
 		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
 	},
-	"containerEnv": {
-		"MetadataProcessing__InputDirectory": "/workspaces/videoschnitt/testdata"
-	},
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/src/InfuseMediaLibrary/Engine.cs
+++ b/src/InfuseMediaLibrary/Engine.cs
@@ -12,14 +12,21 @@ public class Engine
     private readonly ILogger<Engine> _logger;
     private readonly InfuseMetadataXmlService _infuseMetadataXmlService;
     private readonly TargetDirectoryResolver _targetDirectoryResolver;
+    private readonly MediaIntegratorService _mediaIntegratorService;
 
-    public Engine(IOptions<ModuleSettings> moduleSettings, IOptions<ApplicationSettings> applicationSettings, ILogger<Engine> logger, InfuseMetadataXmlService infuseMetadataXmlService, TargetDirectoryResolver targetDirectoryResolver)
+    public Engine(IOptions<ModuleSettings> moduleSettings,
+                  IOptions<ApplicationSettings> applicationSettings,
+                  ILogger<Engine> logger,
+                  InfuseMetadataXmlService infuseMetadataXmlService,
+                  TargetDirectoryResolver targetDirectoryResolver,
+                  MediaIntegratorService mediaIntegratorService)
     {
         _moduleSettings = moduleSettings.Value;
         _applicationSettings = applicationSettings.Value;
         _logger = logger;
         _infuseMetadataXmlService = infuseMetadataXmlService;
         _targetDirectoryResolver = targetDirectoryResolver;
+        _mediaIntegratorService = mediaIntegratorService;
     }
 
     public Result Start(IProgress<string> progress)
@@ -95,7 +102,25 @@ public class Engine
 
             // Informiere wohin die aktuelle Datei (Dateiname) verschoben werden soll
             progress.Report($"Verschiebe Medienset {infuseMetadataXmlFile.FileInfo.Name} nach {targetDirectoryResult.Value.FullName}");
-            progress.Report("Diese Funktion ist noch nicht implementiert.");
+
+            // Prüfe, ob die Suffixe für die Integration von Medien-Dateien in das Infuse-Mediathek-Verzeichnis konfiguriert sind
+            var suffixesToIntegrate = _moduleSettings.VideoVersionSuffixesToIntegrate;
+            if (suffixesToIntegrate == null || suffixesToIntegrate.Any() == false)
+            {
+                // Wenn keine Suffixe konfiguriert sind, bricht den Vorgang ab
+                return Result.Failure("Keine Suffixe für die Integration von Medien-Dateien in das Infuse-Mediathek-Verzeichnis konfiguriert.");
+            }
+
+            // Versuche, die Medien-Dateien in das Zielverzeichnis zu verschieben
+            var moveMediaFilesResult = _mediaIntegratorService.IntegrateMediaSet(mediaSetFiles, targetDirectoryResult.Value, suffixesToIntegrate);
+            if (moveMediaFilesResult.IsFailure)
+            {
+                progress.Report($"Fehler beim Verschieben der Medien-Dateien in das Infuse-Mediathek-Verzeichnis {targetDirectoryResult.Value.FullName}: {moveMediaFilesResult.Error}");
+                progress.Report("Das Medienset wird ignoriert.");
+                continue;
+            }
+
+            progress.Report($"Medienset {infuseMetadataXmlFile.FileInfo.Name} wurde erfolgreich in das Infuse-Mediathek-Verzeichnis {targetDirectoryResult.Value.FullName} verschoben.");
         }
 
         progress.Report("InfuseMediaLibrary-Feature beendet.");

--- a/src/InfuseMediaLibrary/Engine.cs
+++ b/src/InfuseMediaLibrary/Engine.cs
@@ -87,9 +87,9 @@ public class Engine
             var mediaSetFiles = infuseMetadataXmlFileDirectory.GetFiles($"{Path.GetFileNameWithoutExtension(infuseMetadataXmlFile.FileInfo.Name)}*").ToList();
 
             // Informiere über das Album und das Aufnahmedatum, das in den Infuse-Metadaten gefunden wurde und nun für die Benennung des Zielverzeichnisses verwendet wird
-            var recordingDate = infuseMetadataXmlFile.Metadata.Published != null ? infuseMetadataXmlFile.Metadata.Published.Value.ToString("yyyy-MM-dd") : "unbekannt";
+            var recordingDateIsoString = infuseMetadataXmlFile.Metadata.Published != null ? infuseMetadataXmlFile.Metadata.Published.Value.ToString("yyyy-MM-dd") : "unbekannt";
             progress.Report($"Folgendes Album wurde in den Infuse-Metadaten gefunden: {infuseMetadataXmlFile.Metadata.Album}");
-            progress.Report($"Folgendes Aufnahmedatum wurde in den Infuse-Metadaten gefunden: {recordingDate}");
+            progress.Report($"Folgendes Aufnahmedatum wurde in den Infuse-Metadaten gefunden: {recordingDateIsoString}");
 
             // Ermittle mit dem TargetDirectoryResolver das Zielverzeichnis für die Medien-Dateien
             var targetDirectoryResult = _targetDirectoryResolver.ResolveTargetDirectory(mediaSetFiles, _applicationSettings.InfuseMediaLibraryPath);
@@ -112,7 +112,7 @@ public class Engine
             }
 
             // Versuche, die Medien-Dateien in das Zielverzeichnis zu verschieben
-            var moveMediaFilesResult = _mediaIntegratorService.IntegrateMediaSet(mediaSetFiles, targetDirectoryResult.Value, suffixesToIntegrate);
+            var moveMediaFilesResult = _mediaIntegratorService.IntegrateMediaSet(mediaSetFiles, targetDirectoryResult.Value, suffixesToIntegrate, recordingDateIsoString);
             if (moveMediaFilesResult.IsFailure)
             {
                 progress.Report($"Fehler beim Verschieben der Medien-Dateien in das Infuse-Mediathek-Verzeichnis {targetDirectoryResult.Value.FullName}: {moveMediaFilesResult.Error}");

--- a/src/InfuseMediaLibrary/ModuleSettings.cs
+++ b/src/InfuseMediaLibrary/ModuleSettings.cs
@@ -7,4 +7,9 @@ public class ModuleSettings
     /// <summary>
     /// Das Suffix des Dateinamens, das für die Banner-Datei verwendet wird für die Infuse-Mediathek als Titelbild.
     public string? BannerFilePostfix { get; set; } = "-fanart";
+
+    /// <summary>
+    /// Die Varianten-Suffixe, die in den Dateinamen von Videos vorkommen können, einschließlich des Trennzeichens damit diese in die Infuse-Mediathek integriert werden.
+    /// </summary>
+    public List<string>? VideoVersionSuffixesToIntegrate { get; set; } = new List<string> { "-4K60-Medienserver", "-4K30-Medienserver", };
 }

--- a/src/InfuseMediaLibrary/ServiceCollectionExtensions.cs
+++ b/src/InfuseMediaLibrary/ServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<Engine>();
         services.AddScoped<TargetDirectoryResolver>();
         services.AddScoped<InfuseMetadataXmlService>();
+        services.AddScoped<MediaIntegratorService>();
 
         return services;
     }

--- a/src/InfuseMediaLibrary/Services/MediaIntegratorService.cs
+++ b/src/InfuseMediaLibrary/Services/MediaIntegratorService.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Logging;
+using CSharpFunctionalExtensions;
+
+namespace Kurmann.Videoschnitt.InfuseMediaLibrary.Services;
+
+public class MediaIntegratorService
+{
+    private readonly ILogger<MediaIntegratorService> _logger;
+
+    public MediaIntegratorService(ILogger<MediaIntegratorService> logger) => _logger = logger;
+
+    public Result IntegrateMediaSet(IEnumerable<FileInfo> mediaSetFiles, DirectoryInfo targetDirectory, IEnumerable<string> suffixesToIntegrate)
+    {
+        if (mediaSetFiles == null || !mediaSetFiles.Any())
+            return Result.Failure("MediaSetFiles darf nicht null oder leer sein.");
+        if (targetDirectory == null)
+            return Result.Failure("Das Zielverzeichnis muss angegeben sein.");
+        if (suffixesToIntegrate == null || !suffixesToIntegrate.Any())
+            return Result.Failure("SuffixesToIntegrate darf nicht null oder leer sein.");
+
+        _logger.LogInformation($"Integriere Medienset in das Infuse-Mediathek-Verzeichnis {targetDirectory}.");
+
+        // Erstelle das Zielverzeichnis, falls es nicht existiert
+        try
+        {
+            if (!targetDirectory.Exists)
+            {
+                targetDirectory.Create();
+            }
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure($"Das Zielverzeichnis {targetDirectory} konnte nicht erstellt werden: {ex.Message}");
+        }
+
+        // Ermittle die Dateien im Medienset, die in das Infuse-Mediathek-Verzeichnis integriert werden sollen, ignoriere Groß-/Kleinschreibung und die Dateiendung
+        var mediaSetFilesToMove = mediaSetFiles.Where(file => IsFileToMove(file, suffixesToIntegrate)).ToList();
+        _logger.LogInformation($"Es wurden {mediaSetFilesToMove.Count} Dateien im Medienset gefunden, die in das Infuse-Mediathek-Verzeichnis integriert werden sollen.");
+
+        // Bewege die betroffenen Dateien in das Infuse-Mediathek-Verzeichnis
+        foreach (var mediaSetFile in mediaSetFilesToMove)
+        {
+            var targetFilePath = Path.Combine(targetDirectory.FullName, mediaSetFile.Name);
+            try
+            {
+                mediaSetFile.MoveTo(targetFilePath);
+                _logger.LogInformation($"Datei {mediaSetFile.FullName} wurde in das Infuse-Mediathek-Verzeichnis {targetDirectory} verschoben.");
+            }
+            catch (Exception ex)
+            {
+                return Result.Failure($"Datei {mediaSetFile.FullName} konnte nicht in das Infuse-Mediathek-Verzeichnis {targetDirectory} verschoben werden: {ex.Message}");
+            }
+        }
+
+        return Result.Success();
+    }
+
+    private bool IsFileToMove(FileInfo file, IEnumerable<string> suffixesToIntegrate)
+    {
+        var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(file.Name);
+        return suffixesToIntegrate.Any(suffix => fileNameWithoutExtension.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/InfuseMediaLibrary/Services/MediaIntegratorService.cs
+++ b/src/InfuseMediaLibrary/Services/MediaIntegratorService.cs
@@ -56,9 +56,13 @@ public class MediaIntegratorService
             return Result.Failure(errorMessage);
         }
 
-        // Bewege die Datei in das Infuse-Mediathek-Verzeichnis
         var mediaSetFileToMove = mediaSetFilesToMove.First();
-        var targetFilePath = Path.Combine(targetDirectory.FullName, mediaSetFileToMove.Name);
+        
+        // Die integrierte Datei im Infuse-Mediathek-Verzeichnis sollte den Dateinamen ohne Varianten-Suffix haben
+        var fileNameWithoutVariantSuffix = GetFileNameWithoutVariantSuffix(mediaSetFileToMove.Name, suffixesToIntegrate);
+
+        // Bewege die Datei in das Infuse-Mediathek-Verzeichnis
+        var targetFilePath = Path.Combine(targetDirectory.FullName, fileNameWithoutVariantSuffix);
         try
         {   
             mediaSetFileToMove.MoveTo(targetFilePath);
@@ -89,5 +93,24 @@ public class MediaIntegratorService
         }
 
         return fileName;
+    }
+}
+
+public record IntegratedMediaSetFile
+{
+    /// <summary>
+    /// Die Quelldatei, die in das Infuse-Mediathek-Verzeichnis integriert wurde.
+    /// </summary>
+    public FileInfo SourceFile { get; }
+
+    /// <summary>
+    /// Die Zieldatei im Infuse-Mediathek-Verzeichnis.
+    /// </summary>
+    public FileInfo TargetFile { get; }
+
+    public IntegratedMediaSetFile(FileInfo sourceFile, FileInfo targetFile)
+    {
+        SourceFile = sourceFile;
+        TargetFile = targetFile;
     }
 }

--- a/src/InfuseMediaLibrary/Services/TargetDirectoryResolver.cs
+++ b/src/InfuseMediaLibrary/Services/TargetDirectoryResolver.cs
@@ -36,11 +36,11 @@ public class TargetDirectoryResolver
         return Result.Success(targetDirectory);
     }
 
-    public Result<FileInfo> ResolveTargetDirectory(List<FileInfo>? mediaSetFiles, string libraryPath)
+    public Result<DirectoryInfo> ResolveTargetDirectory(List<FileInfo>? mediaSetFiles, string libraryPath)
     {
         if (mediaSetFiles == null || mediaSetFiles.Count == 0)
         {
-            return Result.Failure<FileInfo>("MediaSetFiles darf nicht null oder leer sein.");
+            return Result.Failure<DirectoryInfo>("MediaSetFiles darf nicht null oder leer sein.");
         }
 
         // Filtere XML-Dateien aus den Medienset-Dateien unter Benutzung von StringComparison.OrdinalIgnoreCase
@@ -66,18 +66,28 @@ public class TargetDirectoryResolver
 
         if (albumNameFromMetadata == null)
         {
-            return Result.Failure<FileInfo>("Keine Infuse-Metadaten-XML-Datei gefunden.");
+            return Result.Failure<DirectoryInfo>("Kein Albumname in den Infuse-Metadaten gefunden.");
         }
         if (recordingDate == null)
         {
-            return Result.Failure<FileInfo>("Kein Aufnahmedatum in den Infuse-Metadaten gefunden.");
+            return Result.Failure<DirectoryInfo>("Kein Aufnahmedatum in den Infuse-Metadaten gefunden.");
         }
 
         // Ermittle das Zielverzeichnis mit dem Format "<LibraryPath>/<AlbumNameFromMetadata>/YYYY/YYYY-MM-DD"
         // Das Datum ist als Aufnahmedatum aus den Infuse-Metadaten definiert
         var targetDirectory = Path.Combine(libraryPath, albumNameFromMetadata, recordingDate.Value.Year.ToString(), recordingDate.Value.ToString("yyyy-MM-dd"));
 
-        return Result.Success(new FileInfo(targetDirectory));
+        // Definiere ein DirectoryInfo-Objekt für das Zielverzeichnis
+        try
+        {
+            Directory.CreateDirectory(targetDirectory);
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure<DirectoryInfo>($"Fehler beim Definieren des Zielverzeichnisses {targetDirectory}: {ex.Message}");
+        }
+
+        return Result.Success(new DirectoryInfo(targetDirectory));
     }
     
 }


### PR DESCRIPTION
Medien innerhalb eines Mediensets mit zugehörigem Suffix (bspw. "4K60-Medienserver") werden automatisch in die durch die Konfiguration vorgegebene Infuse-Mediathek verschoben im Format

`Abum/YYYY/YYYY-MM-DD/Titel.ext`