### PR TITLE
API-Endpoint für Final Cut Pro-Workflow

### DIFF
--- a/src/Application/Program.cs
+++ b/src/Application/Program.cs
@@ -38,7 +38,7 @@ public class Program
         builder.Services.AddEndpointsApiExplorer();
         builder.Services.AddSwaggerGen(c =>
         {
-            c.SwaggerDoc("v1", new OpenApiInfo { Title = "Kurmann Videoschnitt API", Version = "v1"});
+            c.SwaggerDoc("v1", new OpenApiInfo { Title = "Kurmann Videoschnitt API", Version = "v1" });
         });
 
         builder.Services.AddSingleton<LogHub>();
@@ -59,11 +59,24 @@ public class Program
         app.UseStaticFiles();
         app.UseRouting();
         app.UseSwagger();
-        app.UseSwagger();
         app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Kurmann Videoschnitt API v1"));
 
         // Minimal API Endpunkte
         app.MapGet("/api/health", () => Results.Ok(new { status = "Healthy" }));
+
+        // Neuen POST-Endpunkt hinzufügen
+        app.MapGet("/api/startprocess", async (FinalCutProWorkflow workflow) =>
+        {
+            var result = await workflow.ExecuteAsync(new Progress<string>(_ => { }));
+            if (result.IsSuccess)
+            {
+                return Results.Ok(new { status = "Process started successfully" });
+            }
+            else
+            {
+                return Results.BadRequest(new { status = "Process failed", error = result.Error });
+            }
+        });
 
         app.MapBlazorHub();
         app.MapFallbackToPage("/_Host");


### PR DESCRIPTION
Der Workflow lässt sich mit einem GET-Request (vorerst) starten bspw. aus einem Apple Automator-Script nach getaner Arbeit.

`curl http://localhost:8080/api/startprocess`

`{"status":"Process started successfully"}%    `