### PR TITLE
Vereinfachte Berechtigungslösung

### DIFF
--- a/src/CommonServices/FileTransferService.cs
+++ b/src/CommonServices/FileTransferService.cs
@@ -67,5 +67,18 @@ namespace Kurmann.Videoschnitt.CommonServices
                 return Result.Failure<string>($"Fehler beim Lesen der Datei {filePath}: {ex.Message}");
             }
         }
+
+        /// <summary>
+        /// Schreibt den Inhalt in eine Datei.
+        /// </summary>
+        /// <param name="content">Der Inhalt, der geschrieben werden soll.</param>
+        /// <param name="filePath">Der Pfad der Datei.</param>
+        /// <returns>Ein Result-Objekt, das den Erfolg oder Fehler enthält.</returns>
+        public async Task<Result> WriteFileAsync(string content, string filePath)
+        {
+            var commandPath = "sh";
+            var arguments = $"-c 'echo \"{content.Replace("\"", "\\\"")}\" > \"{filePath}\"'";
+            return await _executeCommandService.ExecuteCommandAsync(commandPath, arguments);
+        }
     }
 }

--- a/src/CommonServices/FileTransferService.cs
+++ b/src/CommonServices/FileTransferService.cs
@@ -1,90 +1,134 @@
 using System.Text;
-using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
 using Microsoft.Extensions.Logging;
 
-namespace Kurmann.Videoschnitt.CommonServices
+namespace Kurmann.Videoschnitt.CommonServices;
+
+/// <summary>
+/// Service zum Kopieren, Verschieben und Lesen von Dateien.
+/// Dieser Service tritt an die Stelle von System.IO.File, um die Berechtigungen beim Kopieren und Verschieben zu übernehmen.
+/// .NET Core bietet keine Möglichkeit, die Berechtigungen beim Kopieren und Verschieben von Dateien zu übernehmen,
+/// da .NET Core als plattformübergreifendes Framework keine Windows-spezifischen Funktionen unterstützt.
+/// Dieser Service verwendet daher die Unix-Befehle "cp" und "mv" und führt sie in einem externen Prozess aus.
+/// </summary>
+public class FileTransferService
 {
-    /// <summary>
-    /// Service zum Kopieren, Verschieben und Lesen von Dateien.
-    /// Dieser Service tritt an die Stelle von System.IO.File, um die Berechtigungen beim Kopieren und Verschieben zu übernehmen.
-    /// .NET Core bietet keine Möglichkeit, die Berechtigungen beim Kopieren und Verschieben von Dateien zu übernehmen,
-    /// da .NET Core als plattformübergreifendes Framework keine Windows-spezifischen Funktionen unterstützt.
-    /// Dieser Service verwendet daher die Unix-Befehle "cp" und "mv" und führt sie in einem externen Prozess aus.
-    /// </summary>
-    public class FileTransferService
+    private readonly ILogger<FileTransferService> _logger;
+    private readonly ExecuteCommandService _executeCommandService;
+
+    public FileTransferService(ILogger<FileTransferService> logger, ExecuteCommandService executeCommandService)
     {
-        private readonly ILogger<FileTransferService> _logger;
-        private readonly ExecuteCommandService _executeCommandService;
+        _logger = logger;
+        _executeCommandService = executeCommandService;
+    }
 
-        public FileTransferService(ILogger<FileTransferService> logger, ExecuteCommandService executeCommandService)
+    /// <summary>
+    /// Kopiert eine Datei und übernimmt die Berechtigungen.
+    /// </summary>
+    /// <param name="sourcePath">Der Quellpfad der Datei.</param>
+    /// <param name="destinationPath">Der Zielpfad der Datei.</param>
+    /// <returns>Ein Result-Objekt, das den Erfolg oder Fehler enthält.</returns>
+    public async Task<Result> CopyFileWithPermissionsAsync(string sourcePath, string destinationPath)
+    {
+        var commandPath = "cp";
+        var arguments = $"-p \"{sourcePath}\" \"{destinationPath}\"";
+        return await _executeCommandService.ExecuteCommandAsync(commandPath, arguments);
+    }
+
+    /// <summary>
+    /// Verschiebt eine Datei und übernimmt die Berechtigungen.
+    /// </summary>
+    /// <param name="sourcePath">Der Quellpfad der Datei.</param>
+    /// <param name="destinationPath">Der Zielpfad der Datei.</param>
+    /// <returns>Ein Result-Objekt, das den Erfolg oder Fehler enthält.</returns>
+    public async Task<Result> MoveFileWithPermissionsAsync(string sourcePath, string destinationPath)
+    {
+        var commandPath = "mv";
+        var arguments = $"\"{sourcePath}\" \"{destinationPath}\"";
+        return await _executeCommandService.ExecuteCommandAsync(commandPath, arguments);
+    }
+
+    /// <summary>
+    /// Liest den Inhalt einer Datei.
+    /// </summary>
+    /// <param name="filePath">Der Pfad der Datei.</param>
+    /// <returns>Ein Result-Objekt, das den Erfolg oder Fehler enthält.</returns>
+    public async Task<Result<string>> ReadFileAsync(string filePath)
+    {
+        try
         {
-            _logger = logger;
-            _executeCommandService = executeCommandService;
+            var content = await File.ReadAllTextAsync(filePath, Encoding.UTF8);
+            return Result.Success(content);
         }
-
-        /// <summary>
-        /// Kopiert eine Datei und übernimmt die Berechtigungen.
-        /// </summary>
-        /// <param name="sourcePath">Der Quellpfad der Datei.</param>
-        /// <param name="destinationPath">Der Zielpfad der Datei.</param>
-        /// <returns>Ein Result-Objekt, das den Erfolg oder Fehler enthält.</returns>
-        public async Task<Result> CopyFileWithPermissionsAsync(string sourcePath, string destinationPath)
+        catch (Exception ex)
         {
-            var commandPath = "cp";
-            var arguments = $"-p \"{sourcePath}\" \"{destinationPath}\"";
-            return await _executeCommandService.ExecuteCommandAsync(commandPath, arguments);
-        }
-
-        /// <summary>
-        /// Verschiebt eine Datei und übernimmt die Berechtigungen.
-        /// </summary>
-        /// <param name="sourcePath">Der Quellpfad der Datei.</param>
-        /// <param name="destinationPath">Der Zielpfad der Datei.</param>
-        /// <returns>Ein Result-Objekt, das den Erfolg oder Fehler enthält.</returns>
-        public async Task<Result> MoveFileWithPermissionsAsync(string sourcePath, string destinationPath)
-        {
-            var commandPath = "mv";
-            var arguments = $"\"{sourcePath}\" \"{destinationPath}\"";
-            return await _executeCommandService.ExecuteCommandAsync(commandPath, arguments);
-        }
-
-        /// <summary>
-        /// Liest den Inhalt einer Datei.
-        /// </summary>
-        /// <param name="filePath">Der Pfad der Datei.</param>
-        /// <returns>Ein Result-Objekt, das den Erfolg oder Fehler enthält.</returns>
-        public async Task<Result<string>> ReadFileAsync(string filePath)
-        {
-            try
-            {
-                var content = await File.ReadAllTextAsync(filePath, Encoding.UTF8);
-                return Result.Success(content);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError($"Fehler beim Lesen der Datei {filePath}: {ex.Message}");
-                return Result.Failure<string>($"Fehler beim Lesen der Datei {filePath}: {ex.Message}");
-            }
-        }
-
-        /// <summary>
-        /// Schreibt den Inhalt in eine Datei.
-        /// </summary>
-        /// <param name="content">Der Inhalt, der geschrieben werden soll.</param>
-        /// <param name="filePath">Der Pfad der Datei.</param>
-        /// <param name="overwriteExistingFile">Gibt an, ob eine existierende Datei überschrieben werden soll.</param>
-        /// <returns>Ein Result-Objekt, das den Erfolg oder Fehler enthält.</returns>
-        public async Task<Result> WriteFileAsync(string content, string filePath, bool overwriteExistingFile = false)
-        {
-            if (!overwriteExistingFile && File.Exists(filePath))
-            {
-                return Result.Failure($"File '{filePath}' already exists.");
-            }
-
-            var commandPath = "sh";
-            var arguments = $"-c 'echo \"{content.Replace("\"", "\\\"")}\" > \"{filePath}\"'";
-            return await _executeCommandService.ExecuteCommandAsync(commandPath, arguments);
+            _logger.LogError($"Fehler beim Lesen der Datei {filePath}: {ex.Message}");
+            return Result.Failure<string>($"Fehler beim Lesen der Datei {filePath}: {ex.Message}");
         }
     }
+
+    /// <summary>
+    /// Überträgt die Berechtigungen von einer Datei auf eine andere.
+    /// </summary>
+    /// <param name="sourcePath">Der Pfad der Quell-Datei.</param>
+    /// <param name="destinationPath">Der Pfad der Ziel-Datei.</param>
+    /// <returns>Ein Result-Objekt, das den Erfolg oder Fehler enthält.</returns>
+    public async Task<Result> TransferPermissionsAsync(string sourcePath, string destinationPath)
+    {
+        var chmodResult = await _executeCommandService.ExecuteCommandAsync("chmod", $"--reference=\"{sourcePath}\" \"{destinationPath}\"");
+        if (chmodResult.IsFailure)
+        {
+            return Result.Failure($"Fehler beim Übertragen der Berechtigungen: {chmodResult.Error}");
+        }
+
+        var chownResult = await _executeCommandService.ExecuteCommandAsync("chown", $"--reference=\"{sourcePath}\" \"{destinationPath}\"");
+        if (chownResult.IsFailure)
+        {
+            return Result.Failure($"Fehler beim Übertragen des Eigentümers: {chownResult.Error}");
+        }
+
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Überträgt die Berechtigungen von einer Referenzdatei auf alle Dateien in einem Verzeichnis.
+    /// </summary>
+    /// <param name="referenceFilePath">Der Pfad der Referenzdatei.</param>
+    /// <param name="targetDirectory">Das Zielverzeichnis.</param>
+    /// <returns>Ein Result-Objekt, das den Erfolg oder Fehler enthält.</returns>
+    public async Task<Result> TransferDirectoryPermissionsAsync(string referenceFilePath, string targetDirectory)
+    {
+        if (!File.Exists(referenceFilePath))
+        {
+            return Result.Failure($"Referenzdatei '{referenceFilePath}' existiert nicht.");
+        }
+
+        if (!Directory.Exists(targetDirectory))
+        {
+            return Result.Failure($"Zielverzeichnis '{targetDirectory}' existiert nicht.");
+        }
+
+        var targetDirInfo = new DirectoryInfo(targetDirectory);
+
+        foreach (var targetFile in targetDirInfo.GetFiles("*", SearchOption.AllDirectories))
+        {
+            var fileResult = await TransferPermissionsAsync(referenceFilePath, targetFile.FullName);
+            if (fileResult.IsFailure)
+            {
+                return fileResult;
+            }
+        }
+
+        foreach (var targetSubDir in targetDirInfo.GetDirectories("*", SearchOption.AllDirectories))
+        {
+            var subDirResult = await TransferPermissionsAsync(referenceFilePath, targetSubDir.FullName);
+            if (subDirResult.IsFailure)
+            {
+                return subDirResult;
+            }
+        }
+
+        return Result.Success();
+    }
+
 }

--- a/src/CommonServices/FileTransferService.cs
+++ b/src/CommonServices/FileTransferService.cs
@@ -73,9 +73,15 @@ namespace Kurmann.Videoschnitt.CommonServices
         /// </summary>
         /// <param name="content">Der Inhalt, der geschrieben werden soll.</param>
         /// <param name="filePath">Der Pfad der Datei.</param>
+        /// <param name="overwriteExistingFile">Gibt an, ob eine existierende Datei überschrieben werden soll.</param>
         /// <returns>Ein Result-Objekt, das den Erfolg oder Fehler enthält.</returns>
-        public async Task<Result> WriteFileAsync(string content, string filePath)
+        public async Task<Result> WriteFileAsync(string content, string filePath, bool overwriteExistingFile = false)
         {
+            if (!overwriteExistingFile && File.Exists(filePath))
+            {
+                return Result.Failure($"File '{filePath}' already exists.");
+            }
+
             var commandPath = "sh";
             var arguments = $"-c 'echo \"{content.Replace("\"", "\\\"")}\" > \"{filePath}\"'";
             return await _executeCommandService.ExecuteCommandAsync(commandPath, arguments);

--- a/src/InfuseMediaLibrary/Engine.cs
+++ b/src/InfuseMediaLibrary/Engine.cs
@@ -29,7 +29,7 @@ public class Engine
         _mediaIntegratorService = mediaIntegratorService;
     }
 
-    public Result Start(IProgress<string> progress)
+    public async Task<Result> StartAsync(IProgress<string> progress)
     {
         progress.Report("InfuseMediaLibrary-Feature gestartet.");
 
@@ -112,7 +112,7 @@ public class Engine
             }
 
             // Versuche, die Medien-Dateien in das Zielverzeichnis zu verschieben
-            var moveMediaFilesResult = _mediaIntegratorService.IntegrateMediaSet(mediaSetFiles, targetDirectoryResult.Value, suffixesToIntegrate, recordingDateIsoString);
+            var moveMediaFilesResult = await _mediaIntegratorService.IntegrateMediaSet(mediaSetFiles, targetDirectoryResult.Value, suffixesToIntegrate, recordingDateIsoString);
             if (moveMediaFilesResult.IsFailure)
             {
                 progress.Report($"Fehler beim Verschieben der Medien-Dateien in das Infuse-Mediathek-Verzeichnis {targetDirectoryResult.Value.FullName}: {moveMediaFilesResult.Error}");

--- a/src/InfuseMediaLibrary/Engine.cs
+++ b/src/InfuseMediaLibrary/Engine.cs
@@ -29,7 +29,7 @@ public class Engine
         _mediaIntegratorService = mediaIntegratorService;
     }
 
-    public async Task<Result> StartAsync(IProgress<string> progress)
+    public Result Start(IProgress<string> progress)
     {
         progress.Report("InfuseMediaLibrary-Feature gestartet.");
 
@@ -57,7 +57,7 @@ public class Engine
         progress.Report($"Quellverzeichnis für die Integration von Medien in die Infuse-Mediathek: {_applicationSettings.InputDirectory}");
 
         // Versuche, Infuse-Metadaten-XML-Dateien zu finden
-        var infuseMetadataXmlFiles = await _infuseMetadataXmlService.GetInfuseMetadataXmlFilesAsync(_applicationSettings.InputDirectory);
+        var infuseMetadataXmlFiles = _infuseMetadataXmlService.GetInfuseMetadataXmlFiles(_applicationSettings.InputDirectory);
         if (infuseMetadataXmlFiles.IsFailure)
         {
             return Result.Failure($"Fehler beim Ermitteln der Infuse-Metadaten-XML-Dateien: {infuseMetadataXmlFiles.Error}");
@@ -112,7 +112,7 @@ public class Engine
             }
 
             // Versuche, die Medien-Dateien in das Zielverzeichnis zu verschieben
-            var moveMediaFilesResult = await _mediaIntegratorService.IntegrateMediaSetAsync(mediaSetFiles, targetDirectoryResult.Value, suffixesToIntegrate, recordingDateIsoString);
+            var moveMediaFilesResult = _mediaIntegratorService.IntegrateMediaSet(mediaSetFiles, targetDirectoryResult.Value, suffixesToIntegrate, recordingDateIsoString);
             if (moveMediaFilesResult.IsFailure)
             {
                 progress.Report($"Fehler beim Verschieben der Medien-Dateien in das Infuse-Mediathek-Verzeichnis {targetDirectoryResult.Value.FullName}: {moveMediaFilesResult.Error}");

--- a/src/InfuseMediaLibrary/Services/InfuseMetadataXmlService.cs
+++ b/src/InfuseMediaLibrary/Services/InfuseMetadataXmlService.cs
@@ -1,22 +1,16 @@
 using Microsoft.Extensions.Logging;
 using CSharpFunctionalExtensions;
 using Kurmann.Videoschnitt.InfuseMediaLibrary.Entities;
-using Kurmann.Videoschnitt.CommonServices;
 
 namespace Kurmann.Videoschnitt.InfuseMediaLibrary.Services;
 
 public class InfuseMetadataXmlService
 {
     private readonly ILogger<InfuseMetadataXmlService> _logger;
-    private readonly FileTransferService _fileTransferService;
 
-    public InfuseMetadataXmlService(ILogger<InfuseMetadataXmlService> logger, FileTransferService fileTransferService)
-    {
-        _logger = logger;
-        _fileTransferService = fileTransferService;
-    }
+    public InfuseMetadataXmlService(ILogger<InfuseMetadataXmlService> logger) => _logger = logger;
 
-    public async Task<Result<List<CustomProductionInfuseMetadataFile>>> GetInfuseMetadataXmlFilesAsync(string? directoryPath)
+    public Result<List<CustomProductionInfuseMetadataFile>> GetInfuseMetadataXmlFiles(string? directoryPath)
     {
         // Prüfe, ob ein Verzeichnis angegeben wurde
         if (string.IsNullOrWhiteSpace(directoryPath))
@@ -41,7 +35,7 @@ public class InfuseMetadataXmlService
         _logger.LogInformation($"Anzahl der gefundenen XML-Dateien: {xmlFiles.Count}");
 
         // Iteriere über XML-Dateien in den Medienset-Dateien und gib alle validen Infuse-Metadaten-XML-Dateien zurück
-        var customProductionInfuseMetadataFiles = await GetCustomProductionInfuseMetadataFilesAsync(xmlFiles);
+        var customProductionInfuseMetadataFiles = GetCustomProductionInfuseMetadataFiles(xmlFiles);
 
         // Informiere über die Anzahl der gefundenen Infuse-Metadaten-XML-Dateien
         _logger.LogInformation($"Anzahl der gefundenen Infuse-Metadaten-XML-Dateien: {customProductionInfuseMetadataFiles.Count}");
@@ -52,28 +46,21 @@ public class InfuseMetadataXmlService
     /// <summary>
     /// Ermittelt alle validen Infuse-Metadaten-XML-Dateien aus einer Liste von FileInfo-Objekten.
     /// </summary>
-    public async Task<List<CustomProductionInfuseMetadataFile>> GetCustomProductionInfuseMetadataFilesAsync(List<FileInfo> xmlFiles)
+    public List<CustomProductionInfuseMetadataFile> GetCustomProductionInfuseMetadataFiles(List<FileInfo> xmlFiles)
     {
         var customProductionInfuseMetadataFiles = new List<CustomProductionInfuseMetadataFile>();
         foreach (var infuseMetadataXmlFile in xmlFiles)
         {
-            var infuseMetadataXmlContentResult = await _fileTransferService.ReadFileAsync(infuseMetadataXmlFile.FullName);
-            if (infuseMetadataXmlContentResult.IsSuccess)
+            var infuseMetadataXmlContent = File.ReadAllText(infuseMetadataXmlFile.FullName);
+            var infuseMetadataResult = CustomProductionInfuseMetadata.Create(infuseMetadataXmlContent);
+            if (infuseMetadataResult.IsSuccess)
             {
-                var infuseMetadataResult = CustomProductionInfuseMetadata.Create(infuseMetadataXmlContentResult.Value);
-                if (infuseMetadataResult.IsSuccess)
-                {
-                    customProductionInfuseMetadataFiles.Add(new CustomProductionInfuseMetadataFile(infuseMetadataXmlFile, infuseMetadataResult.Value));
-                }
-                else
-                {
-                    // Informiere, dass die XML-Datei nicht als Infuse-Metadaten-XML-Datei erkannt wurde
-                    _logger.LogWarning($"Die XML-Datei {infuseMetadataXmlFile.FullName} konnte nicht als Infuse-Metadaten-XML-Datei erkannt werden. XML-Datei wird ignoriert.");
-                }
+                customProductionInfuseMetadataFiles.Add(new CustomProductionInfuseMetadataFile(infuseMetadataXmlFile, infuseMetadataResult.Value));
             }
             else
             {
-                _logger.LogWarning($"Die XML-Datei {infuseMetadataXmlFile.FullName} konnte nicht gelesen werden: {infuseMetadataXmlContentResult.Error}");
+                // Informiere, dass die XML-Datei nicht als Infuse-Metadaten-XML-Datei erkannt wurde
+                _logger.LogWarning($"Die XML-Datei {infuseMetadataXmlFile.FullName} konnte nicht als Infuse-Metadaten-XML-Datei erkannt werden. XML-Datei wird ignoriert.");
             }
         }
 

--- a/src/InfuseMediaLibrary/Services/MediaIntegratorService.cs
+++ b/src/InfuseMediaLibrary/Services/MediaIntegratorService.cs
@@ -17,9 +17,9 @@ public class MediaIntegratorService
     }
 
     public async Task<Result<IntegratedMediaSetFile>> IntegrateMediaSet(IEnumerable<FileInfo> mediaSetFiles,
-                                                            DirectoryInfo targetDirectory,
-                                                            IEnumerable<string> suffixesToIntegrate,
-                                                            string recordingDateIsoString)
+                                                                        DirectoryInfo targetDirectory,
+                                                                        IEnumerable<string> suffixesToIntegrate,
+                                                                        string recordingDateIsoString)
     {
         if (mediaSetFiles == null || !mediaSetFiles.Any())
             return Result.Failure<IntegratedMediaSetFile>("MediaSetFiles darf nicht null oder leer sein.");

--- a/src/MetadataProcessor/Engine.cs
+++ b/src/MetadataProcessor/Engine.cs
@@ -100,7 +100,17 @@ public class Engine
                 progress.Report($"Dateiname des Infuse-XML-Objekts für Medien-Objekt \n{mediaFile.FullName}:\n{infuseXmlFileName.Value.FullName}");
 
                 // Schreibe die Datei
-                infuseXml.Save(infuseXmlFileName.Value.FullName);
+                var saveResult = await _infuseXmlService.SaveInfuseXmlAsync(infuseXml, infuseXmlFileName.Value.FullName);
+
+                if (saveResult.IsSuccess)
+                {
+                    // Informiere über den Erfolg
+                    progress.Report($"Infuse-XML-Datei für Medien-Objekt {mediaFile.FullName} erfolgreich geschrieben.");
+                }
+                else
+                {
+                    progress.Report($"Fehler beim Schreiben der Infuse-XML-Datei für Medien-Objekt {mediaFile.FullName}: {saveResult.Error}");
+                }
 
                 // Informiere über den Erfolg
                 progress.Report($"Infuse-XML-Datei für Medien-Objekt {mediaFile.FullName} erfolgreich geschrieben.");
@@ -158,7 +168,17 @@ public class Engine
                 var infuseXml = readMpeg4MetadataResult.Value;
 
                 // Schreibe die Datei
-                infuseXml.Save(infuseXmlFileName.Value.FullName);
+                var saveResult = await _infuseXmlService.SaveInfuseXmlAsync(infuseXml, infuseXmlFileName.Value.FullName);
+
+                if (saveResult.IsSuccess)
+                {
+                    // Informiere über den Erfolg
+                    progress.Report($"Infuse-XML-Datei für Medien-Objekt {mediaFile.FullName} erfolgreich geschrieben.");
+                }
+                else
+                {
+                    progress.Report($"Fehler beim Schreiben der Infuse-XML-Datei für Medien-Objekt {mediaFile.FullName}: {saveResult.Error}");
+                }
 
                 // Informiere über den Erfolg
                 progress.Report($"Infuse-XML-Datei für Medien-Objekt {mediaFile.FullName} erfolgreich geschrieben.");

--- a/src/MetadataProcessor/Engine.cs
+++ b/src/MetadataProcessor/Engine.cs
@@ -2,6 +2,7 @@ using Kurmann.Videoschnitt.MetadataProcessor.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Kurmann.Videoschnitt.MetadataProcessor.Entities.SupportedMediaTypes;
+using Kurmann.Videoschnitt.CommonServices;
 using CSharpFunctionalExtensions;
 
 namespace Kurmann.Videoschnitt.MetadataProcessor;
@@ -19,11 +20,12 @@ public class Engine
     private readonly MediaTypeDetectorService _mediaTypeDetectorService;
     private readonly MediaSetVariantService _mediaSetVariantService;
     private readonly InfuseXmlService _infuseXmlService;
+    private readonly FileTransferService _fileTransferService;
 
     public Engine(IOptions<ModuleSettings> moduleSettings, IOptions<ApplicationSettings> applicationSettings, ILogger<Engine> logger,
         MediaFileListenerService mediaFileListenerService, MetadataProcessingService metadataProcessingService, 
         FFmpegMetadataService ffmpegMetadataService, MediaTypeDetectorService mediaTypeDetectorService,
-        MediaSetVariantService mediaSetVariantService, InfuseXmlService infuseXmlService)
+        MediaSetVariantService mediaSetVariantService, InfuseXmlService infuseXmlService, FileTransferService fileTransferService)
     {
         _moduleSettings = moduleSettings.Value;
         _applicationSettings = applicationSettings.Value;
@@ -105,6 +107,16 @@ public class Engine
                 // Informiere über den Erfolg
                 progress.Report($"Infuse-XML-Datei für Medien-Objekt {mediaFile.FullName} erfolgreich geschrieben.");
 
+                // Entferne die spezifischen Berechtigungen der Infuse-XML-Datei, sodass die Berechtiungen von der Verzeichnisstruktur oberhalb übernommen werden
+                var clearSpecificPermissionsResult = await _fileTransferService.ClearSpecificPermissionsAsync(infuseXmlFileName.Value);
+                if (clearSpecificPermissionsResult.IsFailure)
+                {
+                    progress.Report(clearSpecificPermissionsResult.Error);
+                }
+
+                // Informiere über das Entfernen der spezifischen Berechtigungen
+                progress.Report($"Spezifische Berechtigungen der Infuse-XML-Datei {infuseXmlFileName.Value.FullName} wurden entfernt.");
+
                 // Fahre mit der nächsten Datei fort
                 continue;
             }
@@ -162,6 +174,19 @@ public class Engine
 
                 // Informiere über den Erfolg
                 progress.Report($"Infuse-XML-Datei für Medien-Objekt {mediaFile.FullName} erfolgreich geschrieben.");
+
+                // Entferne die spezifischen Berechtigungen der Infuse-XML-Datei, sodass die Berechtigungen von der Verzeichnisstruktur oberhalb übernommen werden
+                var clearSpecificPermissionsResult = await _fileTransferService.ClearSpecificPermissionsAsync(infuseXmlFileName.Value);
+                if (clearSpecificPermissionsResult.IsFailure)
+                {
+                    progress.Report(clearSpecificPermissionsResult.Error);
+                }
+
+                // Informiere über das Entfernen der spezifischen Berechtigungen
+                progress.Report($"Spezifische Berechtigungen der Infuse-XML-Datei {infuseXmlFileName.Value.FullName} wurden entfernt.");
+
+                // Fahre mit der nächsten Datei fort
+                continue;
             }
          
         }

--- a/src/MetadataProcessor/Engine.cs
+++ b/src/MetadataProcessor/Engine.cs
@@ -2,7 +2,6 @@ using Kurmann.Videoschnitt.MetadataProcessor.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Kurmann.Videoschnitt.MetadataProcessor.Entities.SupportedMediaTypes;
-using Kurmann.Videoschnitt.CommonServices;
 using CSharpFunctionalExtensions;
 
 namespace Kurmann.Videoschnitt.MetadataProcessor;
@@ -20,12 +19,11 @@ public class Engine
     private readonly MediaTypeDetectorService _mediaTypeDetectorService;
     private readonly MediaSetVariantService _mediaSetVariantService;
     private readonly InfuseXmlService _infuseXmlService;
-    private readonly FileTransferService _fileTransferService;
 
     public Engine(IOptions<ModuleSettings> moduleSettings, IOptions<ApplicationSettings> applicationSettings, ILogger<Engine> logger,
         MediaFileListenerService mediaFileListenerService, MetadataProcessingService metadataProcessingService, 
         FFmpegMetadataService ffmpegMetadataService, MediaTypeDetectorService mediaTypeDetectorService,
-        MediaSetVariantService mediaSetVariantService, InfuseXmlService infuseXmlService, FileTransferService fileTransferService)
+        MediaSetVariantService mediaSetVariantService, InfuseXmlService infuseXmlService)
     {
         _moduleSettings = moduleSettings.Value;
         _applicationSettings = applicationSettings.Value;
@@ -107,16 +105,6 @@ public class Engine
                 // Informiere über den Erfolg
                 progress.Report($"Infuse-XML-Datei für Medien-Objekt {mediaFile.FullName} erfolgreich geschrieben.");
 
-                // Entferne die spezifischen Berechtigungen der Infuse-XML-Datei, sodass die Berechtiungen von der Verzeichnisstruktur oberhalb übernommen werden
-                var clearSpecificPermissionsResult = await _fileTransferService.ClearSpecificPermissionsAsync(infuseXmlFileName.Value);
-                if (clearSpecificPermissionsResult.IsFailure)
-                {
-                    progress.Report(clearSpecificPermissionsResult.Error);
-                }
-
-                // Informiere über das Entfernen der spezifischen Berechtigungen
-                progress.Report($"Spezifische Berechtigungen der Infuse-XML-Datei {infuseXmlFileName.Value.FullName} wurden entfernt.");
-
                 // Fahre mit der nächsten Datei fort
                 continue;
             }
@@ -174,24 +162,13 @@ public class Engine
 
                 // Informiere über den Erfolg
                 progress.Report($"Infuse-XML-Datei für Medien-Objekt {mediaFile.FullName} erfolgreich geschrieben.");
-
-                // Entferne die spezifischen Berechtigungen der Infuse-XML-Datei, sodass die Berechtigungen von der Verzeichnisstruktur oberhalb übernommen werden
-                var clearSpecificPermissionsResult = await _fileTransferService.ClearSpecificPermissionsAsync(infuseXmlFileName.Value);
-                if (clearSpecificPermissionsResult.IsFailure)
-                {
-                    progress.Report(clearSpecificPermissionsResult.Error);
-                }
-
-                // Informiere über das Entfernen der spezifischen Berechtigungen
-                progress.Report($"Spezifische Berechtigungen der Infuse-XML-Datei {infuseXmlFileName.Value.FullName} wurden entfernt.");
-
-                // Fahre mit der nächsten Datei fort
-                continue;
             }
          
         }
 
         return Result.Success();
     }
+
+
 
 }

--- a/src/MetadataProcessor/Engine.cs
+++ b/src/MetadataProcessor/Engine.cs
@@ -100,17 +100,7 @@ public class Engine
                 progress.Report($"Dateiname des Infuse-XML-Objekts für Medien-Objekt \n{mediaFile.FullName}:\n{infuseXmlFileName.Value.FullName}");
 
                 // Schreibe die Datei
-                var saveResult = await _infuseXmlService.SaveInfuseXmlAsync(infuseXml, infuseXmlFileName.Value.FullName);
-
-                if (saveResult.IsSuccess)
-                {
-                    // Informiere über den Erfolg
-                    progress.Report($"Infuse-XML-Datei für Medien-Objekt {mediaFile.FullName} erfolgreich geschrieben.");
-                }
-                else
-                {
-                    progress.Report($"Fehler beim Schreiben der Infuse-XML-Datei für Medien-Objekt {mediaFile.FullName}: {saveResult.Error}");
-                }
+                infuseXml.Save(infuseXmlFileName.Value.FullName);
 
                 // Informiere über den Erfolg
                 progress.Report($"Infuse-XML-Datei für Medien-Objekt {mediaFile.FullName} erfolgreich geschrieben.");
@@ -168,17 +158,7 @@ public class Engine
                 var infuseXml = readMpeg4MetadataResult.Value;
 
                 // Schreibe die Datei
-                var saveResult = await _infuseXmlService.SaveInfuseXmlAsync(infuseXml, infuseXmlFileName.Value.FullName);
-
-                if (saveResult.IsSuccess)
-                {
-                    // Informiere über den Erfolg
-                    progress.Report($"Infuse-XML-Datei für Medien-Objekt {mediaFile.FullName} erfolgreich geschrieben.");
-                }
-                else
-                {
-                    progress.Report($"Fehler beim Schreiben der Infuse-XML-Datei für Medien-Objekt {mediaFile.FullName}: {saveResult.Error}");
-                }
+                infuseXml.Save(infuseXmlFileName.Value.FullName);
 
                 // Informiere über den Erfolg
                 progress.Report($"Infuse-XML-Datei für Medien-Objekt {mediaFile.FullName} erfolgreich geschrieben.");
@@ -188,7 +168,5 @@ public class Engine
 
         return Result.Success();
     }
-
-
 
 }

--- a/src/MetadataProcessor/Services/InfuseXmlService.cs
+++ b/src/MetadataProcessor/Services/InfuseXmlService.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using CSharpFunctionalExtensions;
 using System.Xml.Linq;
+using Kurmann.Videoschnitt.CommonServices;
 using Kurmann.Videoschnitt.MetadataProcessor.Entities;
 using Kurmann.Videoschnitt.MetadataProcessor.Entities.SupportedMediaTypes;
 
@@ -13,11 +14,13 @@ namespace Kurmann.Videoschnitt.MetadataProcessor.Services
     {
         private readonly ILogger<InfuseXmlService> _logger;
         private readonly FFmpegMetadataService _ffmpegMetadataService;
+        private readonly FileTransferService _fileTransferService;
 
-        public InfuseXmlService(ILogger<InfuseXmlService> logger, FFmpegMetadataService ffmpegMetadataService)
+        public InfuseXmlService(ILogger<InfuseXmlService> logger, FFmpegMetadataService ffmpegMetadataService, FileTransferService fileTransferService)
         {
             _logger = logger;
             _ffmpegMetadataService = ffmpegMetadataService;
+            _fileTransferService = fileTransferService;
         }
 
         public async Task<Result<XDocument>> ReadMetdataFromQuickTimeMovie(QuickTimeMovie quickTimeMovie, IProgress<string> progress)
@@ -41,6 +44,7 @@ namespace Kurmann.Videoschnitt.MetadataProcessor.Services
 
             // Erstelle ein Infuse-XML-Objekt aus den Metadaten
             var infuseXml = ffmpegMetadata.Value.ToInfuseXml();
+
             return infuseXml;
         }
 

--- a/src/MetadataProcessor/Services/InfuseXmlService.cs
+++ b/src/MetadataProcessor/Services/InfuseXmlService.cs
@@ -3,7 +3,6 @@ using CSharpFunctionalExtensions;
 using System.Xml.Linq;
 using Kurmann.Videoschnitt.MetadataProcessor.Entities;
 using Kurmann.Videoschnitt.MetadataProcessor.Entities.SupportedMediaTypes;
-using Kurmann.Videoschnitt.CommonServices;
 
 namespace Kurmann.Videoschnitt.MetadataProcessor.Services
 {
@@ -14,13 +13,11 @@ namespace Kurmann.Videoschnitt.MetadataProcessor.Services
     {
         private readonly ILogger<InfuseXmlService> _logger;
         private readonly FFmpegMetadataService _ffmpegMetadataService;
-        private readonly FileTransferService _fileTransferService;
 
-        public InfuseXmlService(ILogger<InfuseXmlService> logger, FFmpegMetadataService ffmpegMetadataService, FileTransferService fileTransferService)
+        public InfuseXmlService(ILogger<InfuseXmlService> logger, FFmpegMetadataService ffmpegMetadataService)
         {
             _logger = logger;
             _ffmpegMetadataService = ffmpegMetadataService;
-            _fileTransferService = fileTransferService;
         }
 
         public async Task<Result<XDocument>> ReadMetdataFromQuickTimeMovie(QuickTimeMovie quickTimeMovie, IProgress<string> progress)
@@ -71,29 +68,6 @@ namespace Kurmann.Videoschnitt.MetadataProcessor.Services
             progress.Report($"Infuse-XML aus Metadaten von Mpeg4-Video {mpeg4Video.FileInfo.Name}: {infuseXml}");
 
             return infuseXml;
-        }
-
-        public async Task<Result> SaveInfuseXmlAsync(XDocument infuseXml, string filePath, bool overwriteExistingFile = true)
-        {
-            try
-            {
-                var xmlString = infuseXml.ToString();
-                var result = await _fileTransferService.WriteFileAsync(xmlString, filePath, overwriteExistingFile);
-
-                if (result.IsSuccess)
-                {
-                    _logger.LogInformation($"Successfully saved Infuse XML to {filePath}");
-                    return Result.Success();
-                }
-
-                _logger.LogError($"Failed to save Infuse XML to {filePath}: {result.Error}");
-                return Result.Failure(result.Error);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError($"Error saving Infuse XML to {filePath}: {ex.Message}");
-                return Result.Failure($"Error saving Infuse XML to {filePath}: {ex.Message}");
-            }
         }
     }
 }

--- a/src/MetadataProcessor/Services/InfuseXmlService.cs
+++ b/src/MetadataProcessor/Services/InfuseXmlService.cs
@@ -73,12 +73,12 @@ namespace Kurmann.Videoschnitt.MetadataProcessor.Services
             return infuseXml;
         }
 
-        public async Task<Result> SaveInfuseXmlAsync(XDocument infuseXml, string filePath)
+        public async Task<Result> SaveInfuseXmlAsync(XDocument infuseXml, string filePath, bool overwriteExistingFile = true)
         {
             try
             {
                 var xmlString = infuseXml.ToString();
-                var result = await _fileTransferService.WriteFileAsync(xmlString, filePath);
+                var result = await _fileTransferService.WriteFileAsync(xmlString, filePath, overwriteExistingFile);
 
                 if (result.IsSuccess)
                 {

--- a/src/MetadataProcessor/Services/InfuseXmlService.cs
+++ b/src/MetadataProcessor/Services/InfuseXmlService.cs
@@ -3,6 +3,7 @@ using CSharpFunctionalExtensions;
 using System.Xml.Linq;
 using Kurmann.Videoschnitt.MetadataProcessor.Entities;
 using Kurmann.Videoschnitt.MetadataProcessor.Entities.SupportedMediaTypes;
+using Kurmann.Videoschnitt.CommonServices;
 
 namespace Kurmann.Videoschnitt.MetadataProcessor.Services
 {
@@ -13,11 +14,13 @@ namespace Kurmann.Videoschnitt.MetadataProcessor.Services
     {
         private readonly ILogger<InfuseXmlService> _logger;
         private readonly FFmpegMetadataService _ffmpegMetadataService;
+        private readonly FileTransferService _fileTransferService;
 
-        public InfuseXmlService(ILogger<InfuseXmlService> logger, FFmpegMetadataService ffmpegMetadataService)
+        public InfuseXmlService(ILogger<InfuseXmlService> logger, FFmpegMetadataService ffmpegMetadataService, FileTransferService fileTransferService)
         {
             _logger = logger;
             _ffmpegMetadataService = ffmpegMetadataService;
+            _fileTransferService = fileTransferService;
         }
 
         public async Task<Result<XDocument>> ReadMetdataFromQuickTimeMovie(QuickTimeMovie quickTimeMovie, IProgress<string> progress)
@@ -68,6 +71,29 @@ namespace Kurmann.Videoschnitt.MetadataProcessor.Services
             progress.Report($"Infuse-XML aus Metadaten von Mpeg4-Video {mpeg4Video.FileInfo.Name}: {infuseXml}");
 
             return infuseXml;
+        }
+
+        public async Task<Result> SaveInfuseXmlAsync(XDocument infuseXml, string filePath)
+        {
+            try
+            {
+                var xmlString = infuseXml.ToString();
+                var result = await _fileTransferService.WriteFileAsync(xmlString, filePath);
+
+                if (result.IsSuccess)
+                {
+                    _logger.LogInformation($"Successfully saved Infuse XML to {filePath}");
+                    return Result.Success();
+                }
+
+                _logger.LogError($"Failed to save Infuse XML to {filePath}: {result.Error}");
+                return Result.Failure(result.Error);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Error saving Infuse XML to {filePath}: {ex.Message}");
+                return Result.Failure($"Error saving Infuse XML to {filePath}: {ex.Message}");
+            }
         }
     }
 }

--- a/src/Workflows/FinalCutProWorkflow.cs
+++ b/src/Workflows/FinalCutProWorkflow.cs
@@ -32,7 +32,7 @@ public class FinalCutProWorkflow : IAsyncWorkflow
         progress.Report(Environment.NewLine);
         progress.Report("Starte Integration in die Infuse-Mediathek");
 
-        var infuseMediaLibraryResult = await _infuseMediaLibraryEngine.StartAsync(progress);
+        var infuseMediaLibraryResult = _infuseMediaLibraryEngine.Start(progress);
         if (infuseMediaLibraryResult.IsFailure)
         {
             return Result.Failure($"Fehler beim Ausführen des Final Cut Pro Workflows: {infuseMediaLibraryResult.Error}");

--- a/src/Workflows/FinalCutProWorkflow.cs
+++ b/src/Workflows/FinalCutProWorkflow.cs
@@ -32,7 +32,7 @@ public class FinalCutProWorkflow : IAsyncWorkflow
         progress.Report(Environment.NewLine);
         progress.Report("Starte Integration in die Infuse-Mediathek");
 
-        var infuseMediaLibraryResult = _infuseMediaLibraryEngine.Start(progress);
+        var infuseMediaLibraryResult = await _infuseMediaLibraryEngine.StartAsync(progress);
         if (infuseMediaLibraryResult.IsFailure)
         {
             return Result.Failure($"Fehler beim Ausführen des Final Cut Pro Workflows: {infuseMediaLibraryResult.Error}");


### PR DESCRIPTION
Vereinfachte Lösung zur Berechtigung auf Unix-Systemen umgesetzt. Die Berechtigungen vom verschobenen QuickTime-Video und der kopierten XML-Datei werden entfernt, damit die Berechtigungen aus der vorhandenen Hierarchie verwendet werden.