### PR TITLE
feat: Upload release assets workflow

### DIFF
--- a/.github/workflows/upload_release_assets.yml
+++ b/.github/workflows/upload_release_assets.yml
@@ -1,0 +1,29 @@
+name: Upload Release Assets
+
+on:
+  release:
+    types: [published, prereleased]
+  workflow_dispatch:
+
+jobs:
+  upload_release_assets:
+    runs-on: macos-latest
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: Kurmann.Videoschnitt-macos-arm64
+
+      - name: Upload Release Asset
+        run: |
+          gh api --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets?name=Kurmann.Videoschnitt-macos-arm64.tar.gz \
+            -f "@Kurmann.Videoschnitt-macos-arm64.tar.gz"


### PR DESCRIPTION
The code changes add a new GitHub Actions workflow file, `upload_release_assets.yml`, which is responsible for uploading release assets. This workflow is triggered on release events and manual workflow dispatch.

The commit message suggests that the purpose of the code changes is to introduce a workflow for uploading release assets.