### PR TITLE
Ignoriere Dateien, die gerade verwendet werden bspw. während Videokomprimierung (#286)

### DIFF
--- a/src/Common/ExecuteCommandService.cs
+++ b/src/Common/ExecuteCommandService.cs
@@ -69,4 +69,25 @@ public class ExecuteCommandService
 
         return Result.Success(outputLines);
     }
+
+    /// <summary>
+    /// Führt den externen Process aus und retourniert das Ergebnis bei dem ein Exit-Code ungleich 0 als False interpretiert wird.
+    /// Dies ist bspw. bei lsof der Fall, wenn die Datei verwendet wird und ein Exit-Code von 0 zurückgegeben wird wenn kein Prozess die Datei verwendet.
+    /// </summary>
+    /// <param name="commandPath"></param>
+    /// <param name="arguments"></param>
+    /// <returns></returns>
+    public async Task<bool> ExecuteBooleanCommandAsync(string commandPath, string arguments)
+    {
+        _logger.LogInformation($"Executing command: {commandPath} {arguments}");
+
+        var commandResult = await ExecuteCommandAsync(commandPath, arguments);
+        if (commandResult.IsFailure)
+        {
+            _logger.LogInformation("Prozess hat Exit-Code ungleich 0. Wird als True interpretiert.");
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/src/Common/Models/IgnoredFile.cs
+++ b/src/Common/Models/IgnoredFile.cs
@@ -1,0 +1,30 @@
+namespace Kurmann.Videoschnitt.Common.Models;
+
+/// <summary>
+/// Repäsentiert eine ignorierte Datei und den Grund, warum sie ignoriert wird.
+/// </summary>
+/// <param name="FileInfo"></param>
+/// <param name="Reason"></param>
+/// <returns></returns>
+public record IgnoredFile(FileInfo FileInfo, IgnoredFileReason Reason = IgnoredFileReason.NotDefined);
+
+/// <summary>
+/// Gibt an, warum eine Datei ignoriert wird.
+/// </summary>
+public enum IgnoredFileReason
+{
+    /// <summary>
+    /// Der Grund, warum die Datei ignoriert wird, ist nicht definiert.
+    /// </summary>
+    NotDefined,
+
+    /// <summary>
+    /// Die Datei wird ignoriert, weil sie nicht unterstützt wird.
+    /// </summary>
+    NotSupported,
+
+    /// <summary>
+    /// Die Datei wird ignoriert, weil sie aktuell in Verwendung ist.
+    /// </summary>
+    FileInUse
+}

--- a/src/Common/Models/MediaSet.cs
+++ b/src/Common/Models/MediaSet.cs
@@ -7,7 +7,6 @@ namespace Kurmann.Videoschnitt.Common.Models;
 /// Die jeweiligen Dateien für einen Einsatzzweck können auch leer sein, da nicht alle Mediensets für beide Einsatzzwecke konfiguriert sind
 /// oder sich gewisse Dateien beim Verarbeitungsprozess noch nicht im Medienset-Verzeichnis befinden (bspw. während der Videokomprimierung).
 /// </summary>
-/// <param name="MediaSetDirectory"></param>
 /// <param name="Title"></param>
 /// <param name="LocalMediaServerFiles"></param>
 /// <param name="InternetStreaming"></param>

--- a/src/Common/Services/FileSystem/IFileOperations.cs
+++ b/src/Common/Services/FileSystem/IFileOperations.cs
@@ -10,4 +10,5 @@ public interface IFileOperations
     Task<Result> CopyFileAsync(string sourcePath, string destinationPath, bool overwrite = false, bool inheritPermissions = true);
     Result<string> ReadFile(string path);
     Task<Result> CreateDirectoryAsync(string path, bool inheritPermissions = true);
+    Task<Result<bool>> IsFileInUseAsync(string path);
 }

--- a/src/Common/Services/FileSystem/Unix/FileOperations.cs
+++ b/src/Common/Services/FileSystem/Unix/FileOperations.cs
@@ -154,6 +154,24 @@ public class FileOperations : IFileOperations
         }
     }
 
+    /// <summary>
+    /// Gibt an, ob eine Datei verwendet wird. Verwendet das lsof-Tool, um zu überprüfen, ob die Datei von einem Prozess verwendet wird.
+    /// </summary>
+    /// <param name="path"></param>
+    /// <returns></returns>
+    public async Task<Result<bool>> IsFileInUseAsync(string path)
+    {
+        try
+        {
+            var lsofResult = await _executeCommandService.ExecuteBooleanCommandAsync("lsof", $"\"{path}\"");
+            return Result.Success(lsofResult);
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure<bool>($"Fehler beim Überprüfen der Datei: {ex.Message}");
+        }
+    }
+
     private async Task<Result> ResetPermissionsToInherit(string path)
     {
         if (string.IsNullOrWhiteSpace(path))

--- a/src/InfuseMediaLibrary/Services/MediaIntegratorService.cs
+++ b/src/InfuseMediaLibrary/Services/MediaIntegratorService.cs
@@ -108,7 +108,7 @@ public class MediaIntegratorService
             }
         }
         _logger.LogInformation($"Verschiebe Video-Datei {mediaSet.LocalMediaServerFiles.Value.VideoFile.FileInfo.FullName} in das Infuse-Mediathek-Verzeichnis {targetDirectory.FullName}");
-        var moveFileResult = await _fileOperations.MoveFileAsync(mediaSet.LocalMediaServerFiles.Value.VideoFile.FileInfo.FullName, targetFilePathResult.Value.FullName);
+        var moveFileResult = await _fileOperations.MoveFileAsync(mediaSet.LocalMediaServerFiles.Value.VideoFile.FileInfo.FullName, targetFilePathResult.Value.FullName, true);
         if (moveFileResult.IsFailure)
         {
             return Result.Failure<Maybe<LocalMediaServerFiles>>($"Die Video-Datei {mediaSet.LocalMediaServerFiles.Value.VideoFile.FileInfo.FullName} konnte nicht in das Infuse-Mediathek-Verzeichnis {targetDirectory.FullName} verschoben werden. Fehler: {moveFileResult.Error}");

--- a/src/MetadataProcessor/ServiceCollectionExtensions.cs
+++ b/src/MetadataProcessor/ServiceCollectionExtensions.cs
@@ -5,6 +5,8 @@ using Kurmann.Videoschnitt.Common;
 using Kurmann.Videoschnitt.Common.Services.Metadata;
 using Kurmann.Videoschnitt.Common.Services.ImageProcessing;
 using Kurmann.Videoschnitt.Common.Services.ImageProcessing.MacOS;
+using Kurmann.Videoschnitt.Common.Services.FileSystem;
+using Kurmann.Videoschnitt.Common.Services.FileSystem.Unix;
 
 namespace Kurmann.Videoschnitt.MetadataProcessor;
 
@@ -22,6 +24,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<MediaSetService>();
         services.AddScoped<MediaPurposeOrganizer>();
         services.AddScoped<IColorConversionService, MacOSColorConversionService>();
+        services.AddScoped<IFileOperations, FileOperations>();
 
         services.AddCommonServicesEngine(configuration);
 


### PR DESCRIPTION
* Implemented IsFileInUse

* Defined IgnoredFile record

* feat: Add ExecuteBooleanCommandAsync method to ExecuteCommandService

This commit adds the `ExecuteBooleanCommandAsync` method to the `ExecuteCommandService` class. This method allows for executing an external process and returning a boolean result based on the exit code. If the exit code is non-zero, the method returns `false`, otherwise it returns `true`.

Note: The commit message has been generated based on the provided code changes and recent user commits.

* feat: Update IsFileInUse method to use async

The IsFileInUse method in the IFileOperations interface has been updated to use the async keyword. This change allows for asynchronous execution of the method, improving performance and responsiveness.

Note: The commit message has been generated based on the provided code changes and recent user commits.

* feat: Update IsFileInUse method to use async

This commit updates the IsFileInUse method in the IFileOperations interface to use the async keyword. By making the method asynchronous, it improves performance and responsiveness.

Note: The commit message has been generated based on the provided code changes and recent user commits.

* feat: Remove unnecessary parameter in MediaSet constructor

The `MediaSet` constructor in the `MediaSet.cs` file had an unnecessary `MediaSetDirectory` parameter, which has been removed.

* feat: Update MoveFileAsync method to overwrite existing files

The MoveFileAsync method in the MediaIntegratorService class has been updated to include an additional parameter that allows overwriting existing files. This change ensures that if a file with the same name already exists in the target directory, it will be replaced with the new file being moved.

Note: The commit message has been generated based on the provided code changes and recent user commits.

* feat: Add Kurmann.Videoschnitt.Common.Services.FileSystem.Unix namespace

This commit adds the `Kurmann.Videoschnitt.Common.Services.FileSystem.Unix` namespace to the `ServiceCollectionExtensions.cs` file. This namespace is required for the new `IFileOperations` service implementation.

Note: The commit message has been generated based on the provided code changes and recent user commits.

* feat: Filter files in use during media set processing

This commit adds functionality to filter out files that are currently in use during the media set processing. It checks if each file is being written to or used by another process and adds them to the list of ignored files. This ensures that only fully available files are processed and avoids any potential errors or inconsistencies.

Note: The commit message has been generated based on the provided code changes and recent user commits.