### PR TITLE
Copy video file to target directory instead of moving it

### DIFF
--- a/src/InfuseMediaLibrary/Services/Integration/VideoIntegrator.cs
+++ b/src/InfuseMediaLibrary/Services/Integration/VideoIntegrator.cs
@@ -116,7 +116,7 @@ internal class VideoIntegrator
         }
 
         // Verschiebe die Videodatei in das lokale Infuse-Mediathek-Verzeichnis und überschreibe die Datei falls sie bereits existiert
-        var fileMoveResult = await _fileOperations.MoveFileAsync(supportedVideo, targetFilePath, true, true);
+        var fileMoveResult = await _fileOperations.CopyFileAsync(supportedVideo, targetFilePath, true, true);
         if (fileMoveResult.IsFailure)
         {
             return Result.Failure<Maybe<Result>>($"Die Video-Datei {supportedVideo} konnte nicht in das Infuse-Mediathek-Verzeichnis {targetDirectory.Value.FullName} verschoben werden. Fehler: {fileMoveResult.Error}");


### PR DESCRIPTION
The code change updates the `VideoIntegrator` class in the `InfuseMediaLibrary.Services.Integration` namespace. Instead of moving the video file to the target directory, it now copies the file using the `CopyFileAsync` method from the `_fileOperations` service. This change ensures that the original video file is not deleted from its source location.

Note: The commit message has been generated based on the provided code changes and recent commits.