### PR TITLE
Konfiguration: Möglichkeit mit CLI Werte in der `.env`-Datei zu bearbeiten

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -32,6 +32,7 @@
                 "-m",
                 "typer",
                 "${workspaceFolder}/src/original_media_integrator/app.py",
+                "import-media",
                 "utils",
                 "docs",
                 "--name",
@@ -94,6 +95,29 @@
             "group": "build"
         },
         {
+            "label": "generate-cli-docs-config-manager",
+            "type": "shell",
+            "command": "/Library/Frameworks/Python.framework/Versions/3.11/bin/python3",
+            "args": [
+                "-m",
+                "typer",
+                "${workspaceFolder}/src/config_manager/app.py",
+                "utils",
+                "docs",
+                "--name",
+                "config-manager",
+                "--output",
+                "${workspaceFolder}/docs/cli/config_manager.md"
+            ],
+            "problemMatcher": [],
+            "options": {
+                "env": {
+                    "PYTHONPATH": "${workspaceFolder}/src"
+                }
+            },
+            "group": "build"
+        },
+        {
             "label": "generate-all-cli-docs",
             "type": "shell",
             "command": "echo",
@@ -102,7 +126,8 @@
                 "generate-cli-docs-apple-compressor-manager",
                 "generate-cli-docs-original-media-integrator",
                 "generate-cli-docs-emby-integrator",
-                "generate-cli-docs-online-medialibrary-manager"
+                "generate-cli-docs-online-medialibrary-manager",
+                "generate-cli-docs-config-manager"
             ],
             "problemMatcher": [],
             "group": {

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Die Grundlage für die CLI ist das [CLI-Design](/docs/CLI-Design.md).
 - [Emby Integrator](/docs/cli/emby_integrator.md)
 - [Online Medialibrary Manager](/docs/cli/online_medialibrary_manager.md)
 - [Original Media Integrator](/docs/cli/original_media_integrator.md)
+- [Configuration Manager](/docs/cli/config_manager.md)
 
 ## Mitwirken
 

--- a/docs/cli/config_manager.md
+++ b/docs/cli/config_manager.md
@@ -1,0 +1,72 @@
+# `config-manager`
+
+Config Manager CLI für Kurmann Videoschnitt
+
+**Usage**:
+
+```console
+$ config-manager [OPTIONS] COMMAND [ARGS]...
+```
+
+**Options**:
+
+* `--install-completion`: Install completion for the current shell.
+* `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
+* `--help`: Show this message and exit.
+
+**Commands**:
+
+* `delete`: Löscht einen Konfigurationswert aus der...
+* `list`: Listet alle Konfigurationswerte in der...
+* `set`: Setzt einen Konfigurationswert in der...
+
+## `config-manager delete`
+
+Löscht einen Konfigurationswert aus der .env-Datei.
+
+**Usage**:
+
+```console
+$ config-manager delete [OPTIONS] KEY
+```
+
+**Arguments**:
+
+* `KEY`: Der Schlüssel, den du löschen möchtest.  [required]
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+## `config-manager list`
+
+Listet alle Konfigurationswerte in der .env-Datei auf.
+
+**Usage**:
+
+```console
+$ config-manager list [OPTIONS]
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+## `config-manager set`
+
+Setzt einen Konfigurationswert in der .env-Datei.
+
+**Usage**:
+
+```console
+$ config-manager set [OPTIONS] KEY VALUE
+```
+
+**Arguments**:
+
+* `KEY`: Der Schlüssel, den du setzen möchtest.  [required]
+* `VALUE`: Der Wert, der dem Schlüssel zugewiesen werden soll.  [required]
+
+**Options**:
+
+* `--help`: Show this message and exit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kurmann-videoschnitt"
-version = "0.57.2"
+version = "0.58.0"
 description = "Sammlung von Werkzeugen zur Automatisierungen im privaten Videoschnitt"
 readme = "README.md"
 requires-python = ">=3.8,<4.0"
@@ -25,6 +25,7 @@ apple-compressor-manager = "apple_compressor_manager.app:app"
 original-media-integrator = "original_media_integrator.app:app"
 emby-integrator = "emby_integrator.app:app"
 online-medialibrary-manager = "online_medialibrary_manager.app:app"
+config-manager = "config_manager.app:app" 
 
 [project.urls]
 Homepage = "https://github.com/kurmann/videoschnitt"

--- a/src/config_manager/app.py
+++ b/src/config_manager/app.py
@@ -1,0 +1,84 @@
+# src/config_manager/app.py
+
+import typer
+from pathlib import Path
+from dotenv import load_dotenv, set_key, unset_key
+import os
+
+app = typer.Typer(help="Config Manager CLI für Kurmann Videoschnitt")
+
+# Pfad zur .env-Datei
+ENV_FILE_PATH = Path.home() / "Library/Application Support/Kurmann/Videoschnitt/.env"
+
+def ensure_env_file_exists():
+    """
+    Stellt sicher, dass die .env-Datei existiert. Erstellt sie andernfalls.
+    """
+    if not ENV_FILE_PATH.parent.exists():
+        ENV_FILE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if not ENV_FILE_PATH.exists():
+        ENV_FILE_PATH.touch()
+
+@app.command("set")
+def set_config(
+    key: str = typer.Argument(..., help="Der Schlüssel, den du setzen möchtest."),
+    value: str = typer.Argument(..., help="Der Wert, der dem Schlüssel zugewiesen werden soll.")
+):
+    """
+    Setzt einen Konfigurationswert in der .env-Datei.
+    """
+    ensure_env_file_exists()
+    load_dotenv(dotenv_path=ENV_FILE_PATH)
+    
+    try:
+        set_key(str(ENV_FILE_PATH), key, value)
+        typer.echo(f"Setze {key}={value} in {ENV_FILE_PATH}")
+    except Exception as e:
+        typer.secho(f"Fehler beim Setzen der Konfiguration: {e}", fg=typer.colors.RED)
+        raise typer.Exit(code=1)
+
+@app.command("delete")
+def delete_config(
+    key: str = typer.Argument(..., help="Der Schlüssel, den du löschen möchtest.")
+):
+    """
+    Löscht einen Konfigurationswert aus der .env-Datei.
+    """
+    if not ENV_FILE_PATH.exists():
+        typer.secho(f".env-Datei existiert nicht unter {ENV_FILE_PATH}", fg=typer.colors.RED)
+        raise typer.Exit(code=1)
+    
+    load_dotenv(dotenv_path=ENV_FILE_PATH)
+    
+    if not os.getenv(key):
+        typer.secho(f"Schlüssel '{key}' existiert nicht in der .env-Datei.", fg=typer.colors.YELLOW)
+        raise typer.Exit(code=1)
+    
+    try:
+        unset_key(str(ENV_FILE_PATH), key)
+        typer.echo(f"Lösche {key} aus {ENV_FILE_PATH}")
+    except Exception as e:
+        typer.secho(f"Fehler beim Löschen der Konfiguration: {e}", fg=typer.colors.RED)
+        raise typer.Exit(code=1)
+
+@app.command("list")
+def list_configs():
+    """
+    Listet alle Konfigurationswerte in der .env-Datei auf.
+    """
+    if not ENV_FILE_PATH.exists():
+        typer.secho(f".env-Datei existiert nicht unter {ENV_FILE_PATH}", fg=typer.colors.RED)
+        raise typer.Exit(code=1)
+    
+    load_dotenv(dotenv_path=ENV_FILE_PATH)
+    env_vars = {key: value for key, value in os.environ.items() if key.startswith("original_media_") or key.startswith("online_media_")}
+    
+    if not env_vars:
+        typer.echo("Keine Konfigurationswerte gefunden.")
+        raise typer.Exit()
+    
+    for key, value in env_vars.items():
+        typer.echo(f"{key}={value}")
+
+if __name__ == "__main__":
+    app()

--- a/src/utils/config_loader.py
+++ b/src/utils/config_loader.py
@@ -3,14 +3,22 @@
 from dotenv import load_dotenv
 from pathlib import Path
 import os
+import logging
+
+# Konfiguriere das Logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+ENV_FILE_PATH = Path.home() / "Library/Application Support/Kurmann/Videoschnitt/.env"
 
 def load_app_env():
     """
     Lädt die .env Datei aus ~/Library/Application Support/Kurmann/Videoschnitt/.env
     """
-    env_path = Path.home() / "Library/Application Support/Kurmann/Videoschnitt/.env"
-    if env_path.exists():
-        load_dotenv(dotenv_path=env_path)
-        return env_path
+    if ENV_FILE_PATH.exists():
+        load_dotenv(dotenv_path=ENV_FILE_PATH)
+        logger.info(f".env Datei geladen von: {ENV_FILE_PATH}")
+        return ENV_FILE_PATH
     else:
+        logger.warning(f".env Datei nicht gefunden unter: {ENV_FILE_PATH}")
         return None


### PR DESCRIPTION
Du hast erfolgreich ein neues Package config-manager erstellt, das es dir ermöglicht, Konfigurationswerte in deiner .env-Datei über die CLI zu setzen und zu löschen. Hier sind die wesentlichen Schritte zusammengefasst:

	1.	Erstellen des config_manager Packages: Implementiere die CLI-Befehle set, delete und list.
	2.	Integration in pyproject.toml: Füge den Entry Point hinzu, damit das CLI als eigenständiger Befehl verfügbar ist.
	3.	Implementierung der Funktionen: Setze und lösche Schlüssel-Wert-Paare in der .env-Datei mit entsprechender Fehlerbehandlung.
	4.	Erweiterung der tasks.json: Füge eine Task zur automatischen Dokumentationsgenerierung für das neue Package hinzu.
	5.	Testen der CLI-Befehle: Stelle sicher, dass die Befehle wie erwartet funktionieren.